### PR TITLE
LIBFCREPO-286. Multicast incoming messages to solr and triplestore queues.

### DIFF
--- a/umd-fcrepo-event-router/src/main/cfg/edu.umd.lib.fcrepo.camel.router.cfg
+++ b/umd-fcrepo-event-router/src/main/cfg/edu.umd.lib.fcrepo.camel.router.cfg
@@ -4,11 +4,17 @@ error.maxRedeliveries=10
 # The camel URI for the incoming message stream.
 input.queue.name=queue:fedora
 
-# Name of the queue to send batch events to.
-batch.queue.name=queue:fedorafiltered
+# Name of the queue to send solr batch events to.
+batch.solrqueue.name=queue:fedorasolr
 
-# Name of the queue to send live events to.
-live.queue.name=queue:fedorafiltered
+# Name of the queue to send solr live events to.
+live.solrqueue.name=queue:fedorasolr
+
+# Name of the queue to send triplestore batch events to.
+batch.triplestorequeue.name=queue:fedoratriplestore
+
+# Name of the queue to send triplestore live events to.
+live.triplestorequeue.name=queue:fedoratriplestore
 
 # Name of the batch load user
 batch.user=

--- a/umd-fcrepo-event-router/src/main/java/edu/umd/lib/fcrepo/camel/routing/Router.java
+++ b/umd-fcrepo-event-router/src/main/java/edu/umd/lib/fcrepo/camel/routing/Router.java
@@ -67,11 +67,13 @@ public class Router extends RouteBuilder{
                 .otherwise()
                     .setHeader("JMSPriority").simple("{{batch.jms.priority}}").end()
                     .setHeader(BATCH_HEADER).simple("true").end()
-                    .to("broker:{{batch.queue.name}}");
+                    .multicast()
+                    .to("broker:{{batch.solrqueue.name}}", "broker:{{batch.triplestorequeue.name}}");
 
         from("direct:live.queue")
             .log(LoggingLevel.DEBUG, logger, "Routed to live queue.")
-            .to("broker:{{live.queue.name}}");
+            .multicast()
+            .to("broker:{{live.solrqueue.name}}", "broker:{{live.triplestorequeue.name}}");
     }
 
     private String headerString(String headerName) {

--- a/umd-fcrepo-event-router/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/umd-fcrepo-event-router/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -24,8 +24,10 @@
      <cm:default-properties>
        <cm:property name="error.maxRedeliveries" value="10"/>
        <cm:property name="input.queue.name" value="queue:fedora"/>
-       <cm:property name="batch.queue.name" value="queue:fedorafiltered"/>
-       <cm:property name="live.queue.name" value="queue:fedorafiltered"/>
+       <cm:property name="batch.solrqueue.name" value="queue:fedorasolr"/>
+       <cm:property name="live.solrqueue.name" value="queue:fedorasolr"/>
+       <cm:property name="batch.triplestorequeue.name" value="queue:fedoratriplestore"/>
+       <cm:property name="live.triplestorequeue.name" value="queue:fedoratriplestore"/>
        <cm:property name="batch.user" value=""/>
        <cm:property name="batch.jms.priority" value="4"/>
        <cm:property name="batch.skip.pcdm.container" value="true"/>


### PR DESCRIPTION
With the switch from topic to queue, the messages could only be delivered to a single listener unless it is multicasted.

https://issues.umd.edu/browse/LIBFCREPO-286