### PR TITLE
LIBFCREPO-361. Added batch.skip.paths configuration.

### DIFF
--- a/umd-fcrepo-event-router/src/main/cfg/edu.umd.lib.fcrepo.camel.router.cfg
+++ b/umd-fcrepo-event-router/src/main/cfg/edu.umd.lib.fcrepo.camel.router.cfg
@@ -19,3 +19,6 @@ batch.jms.priority=4
 
 # Skip indexing of "/pcdm" node on batch mode
 batch.skip.pcdm.container=true
+
+# Comma-separated list of paths to skip indexing in batch mode
+batch.skip.paths=

--- a/umd-fcrepo-event-router/src/main/cfg/edu.umd.lib.fcrepo.camel.router.cfg
+++ b/umd-fcrepo-event-router/src/main/cfg/edu.umd.lib.fcrepo.camel.router.cfg
@@ -17,8 +17,5 @@ batch.user=
 # Range: 1 - 10. Default priority of all Fedora messages is 4.
 batch.jms.priority=4
 
-# Skip indexing of "/pcdm" node on batch mode
-batch.skip.pcdm.container=true
-
 # Comma-separated list of paths to skip indexing in batch mode
 batch.skip.paths=

--- a/umd-fcrepo-event-router/src/main/java/edu/umd/lib/fcrepo/camel/routing/Router.java
+++ b/umd-fcrepo-event-router/src/main/java/edu/umd/lib/fcrepo/camel/routing/Router.java
@@ -67,7 +67,7 @@ public class Router extends RouteBuilder{
                             simple("{{batch.skip.pcdm.container}} == 'true'"),
                             simple(headerString(JMS_IDENTIFIER) + " == '/pcdm'")
                         ),
-                        simple(headerString(JMS_IDENTIFIER) + " in {{batch.skip.paths}}")
+                        simple(headerString(JMS_IDENTIFIER) + " in '{{batch.skip.paths}}'")
                     )
                     )
                     .log(LoggingLevel.DEBUG, logger,

--- a/umd-fcrepo-event-router/src/main/java/edu/umd/lib/fcrepo/camel/routing/Router.java
+++ b/umd-fcrepo-event-router/src/main/java/edu/umd/lib/fcrepo/camel/routing/Router.java
@@ -61,15 +61,7 @@ public class Router extends RouteBuilder{
         from("direct:batch.queue")
             .log(LoggingLevel.DEBUG, logger, "Routed to batch queue.")
             .choice()
-                .when(
-                    or(
-                        and(
-                            simple("{{batch.skip.pcdm.container}} == 'true'"),
-                            simple(headerString(JMS_IDENTIFIER) + " == '/pcdm'")
-                        ),
-                        simple(headerString(JMS_IDENTIFIER) + " in '{{batch.skip.paths}}'")
-                    )
-                    )
+                .when(simple(headerString(JMS_IDENTIFIER) + " in '{{batch.skip.paths}}'"))
                     .log(LoggingLevel.DEBUG, logger,
                         "Suppressing '" + headerString(JMS_IDENTIFIER) + "' node event for batch user.")
                     .stop()


### PR DESCRIPTION
List of paths to skip sending to indexing during batch operations. This is to allow more than just the hardcoded "/pcdm" path to be omitted from indexing during batch operations.

https://issues.umd.edu/browse/LIBFCREPO-361