### PR TITLE
LIBFCREPO-448. Implement Broadcast fcrepo Camel extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 **/target
 
+# Ignore Eclipse configuration files
+.settings/
+.project
+.classpath

--- a/README.md
+++ b/README.md
@@ -25,8 +25,14 @@ feature:install umd-fcrepo-ldpath
 feature:install umd-fcrepo-indexing-solr
 ```
 
-**Note:** The `fcrepo-ldpath` and `fcrepo-indexing-solr` modules should be uninstalled before installing the caching modules. 
+**Note:** The `fcrepo-ldpath` and `fcrepo-indexing-solr` modules should be uninstalled before installing the caching modules.
+
+Install the UMD Fcrepo Broadcast module.
+
+```
+feature:install umd-fcrepo-broadcast
+```
 
 ## License
- 
+
 See the [LICENSE](LICENSE.md) file for license rights and limitations (Apache 2.0).

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,8 @@
 
         <!-- dependencies -->
         <activemq.version>5.14.1</activemq.version>
+        <osgi-core.version>5.0.0</osgi-core.version>
+        <osgi-compendium.version>5.0.0</osgi-compendium.version>
         <camel.version>2.18.0</camel.version>
         <marmotta.version>3.3.0</marmotta.version>
         <fcrepo-camel.version>4.5.0</fcrepo-camel.version>
@@ -49,10 +51,21 @@
         <module>umd-fcrepo-ldpath-blueprint</module>
         <module>umd-fcrepo-batch-ldcache-file</module>
         <module>umd-features</module>
+        <module>umd-fcrepo-broadcast</module>
     </modules>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.core</artifactId>
+                <version>${osgi-core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.compendium</artifactId>
+                <version>${osgi-compendium.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-core</artifactId>

--- a/umd-fcrepo-broadcast/README.md
+++ b/umd-fcrepo-broadcast/README.md
@@ -1,0 +1,63 @@
+# UMD Fcrepo Broadcast
+
+* Routes the messages from an "input.stream" queue/topic to one or more "message.recipients" queues
+* Multiple service instances can be created
+
+## Configuration
+
+A service instance is created by adding an "edu.umd.lib.fcrepo.camel.broadcast-[ROUTE_IDENTIFIER].cfg"
+into the Karaf etc/ directory, where [ROUTE_IDENTIFIER] is a unique name for
+the route.
+
+### Example Configuration:
+
+The following configuration files demonstrate that it is possible to have
+two completely different service instances, using different "input.stream" and
+"message.recipients", simply by creating appropriately named configuration
+files in the Karaf etc/ directory.
+
+#### Service Instance 1 - edu.umd.lib.fcrepo.camel.broadcast-fixitysuccess.cfg
+
+A service instance that receives messages from the "activemq:queue:fixitysuccess"
+input stream, and rebroadcast copies to each of the recipients in the "message.recipients"
+property (in this case, two different files in /tmp). In these configurations,
+the [ROUTE_IDENTIFIER] was chosen to be the related to the "input.stream" value,
+but this is entirely arbitrary.
+
+```
+# Which queue/topic to listen to on the above broker
+input.stream=activemq:queue:fixityfailure
+
+# Comma separated list of recipient queues to broadcast the incoming messages to
+# for example: "broker:queue:fcrepo-serialization,broker:queue:fcrepo-indexing-triplestore"
+message.recipients=file:/tmp/?fileName=umd-broadcast-fixityfailure.log&fileExist=Append,file:/tmp/?fileName=fixityfailure.log&fileExist=Append
+
+# In the event of failure, the maximum number of times a redelivery will be attempted.
+error.maxRedeliveries=10
+```
+
+#### Service Instance 2 - edu.umd.lib.fcrepo.camel.broadcast-fixityfailure.cfg
+
+A service instance that receives messages from the "activemq:queue:fixityfailure"
+input stream, and rebroadcast copies to each of the recipients in the "message.recipients"
+property (in this case, two different files in /tmp).
+
+```
+# Which queue/topic to listen to on the above broker
+input.stream=activemq:queue:fixityfailure
+
+# Comma separated list of recipient queues to broadcast the incoming messages to
+# for example: "broker:queue:fcrepo-serialization,broker:queue:fcrepo-indexing-triplestore"
+message.recipients=file:/tmp/?fileName=umd-broadcast-fixityfailure.log&fileExist=Append,file:/tmp/?fileName=fixityfailure.log&fileExist=Append
+
+# In the event of failure, the maximum number of times a redelivery will be attempted.
+error.maxRedeliveries=10
+```
+
+In the Karaf "route-list", the routes will show as distinct routes, named
+for the "input.stream" they are using, i.e.:
+
+```
+UmdFcrepoBroadcast         Broadcast activemq:queue:fixityfailure
+UmdFcrepoBroadcast         Broadcast activemq:queue:fixitysuccess
+```

--- a/umd-fcrepo-broadcast/pom.xml
+++ b/umd-fcrepo-broadcast/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" 
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <!--
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>edu.umd.lib.fcrepo</groupId>
+        <artifactId>umd-fcrepo-camel-extensions</artifactId>
+        <version>1.3.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>umd-fcrepo-broadcast</artifactId>
+    <packaging>bundle</packaging>
+
+    <name>UMD Fcrepo Broadcast</name>
+    <description>UMD Fcrepo Broadcast Project.</description>
+
+    <properties>
+        <osgi.import.packages>
+            *
+        </osgi.import.packages>
+        <osgi.export.packages>
+            edu.umd.lib.fcrepo.camel.broadcast*;version=${project.version}
+        </osgi.export.packages>
+    </properties>
+
+    <dependencies>
+        <!-- OSGI -->
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.compendium</artifactId>
+        </dependency>
+
+        <!-- Apache Camel -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-core</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/umd-fcrepo-broadcast/src/main/java/edu/umd/lib/fcrepo/camel/broadcast/BroadcastDispatcher.java
+++ b/umd-fcrepo-broadcast/src/main/java/edu/umd/lib/fcrepo/camel/broadcast/BroadcastDispatcher.java
@@ -1,0 +1,101 @@
+package edu.umd.lib.fcrepo.camel.broadcast;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A broadcast service instance, typically created and controlled via the BroadcastFactory.
+ * 
+ * This implementation is inspired by the code in Chapter 2, Recipe 6 of
+ * 
+ *  Nierbeck A., "Apache Karaf Cookbook : Over 60 Recipes to Help You Get the Most Out of Apache Karaf Deployments.",
+ *  Birmingham, UK: Packt Pub; 2014.
+ */
+public class BroadcastDispatcher {
+
+    private String inputStream;
+    private String messageRecipients;
+    private RouteBuilder rb;
+    private CamelContext cc;
+
+    private Logger log = LoggerFactory.getLogger(BroadcastDispatcher.class);
+
+    public BroadcastDispatcher() { }
+
+    /**
+     * Builds and starts the broadcast route.
+     */
+    public void start() {
+        try {
+            rb = buildBroadcastRouter();
+            log.info("Route " + rb + " starting..."); 
+            cc.start();
+            cc.addRoutes(rb);
+        } catch (Exception ex) {
+            log.error("Could not process Broadcast " + ex); 
+        }
+    }
+
+    /**
+     * Returns a RouteBuilder, using the values from the instance variables
+     * 
+     * @return 
+     * @throws Exception
+     */
+    protected RouteBuilder buildBroadcastRouter() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+              from(inputStream)
+              .routeId("Broadcast " + inputStream)
+              .description("Broadcast messages from one queue/topic to other specified queues/topics.")
+              .log("Distributing message: ${headers[org.fcrepo.jms.timestamp]}: " +
+                      "${headers[org.fcrepo.jms.identifier]}:${headers[org.fcrepo.jms.eventType]}")
+              .recipientList(simple(messageRecipients)).ignoreInvalidEndpoints();
+            }
+        };
+    }
+
+    /**
+     * Stops the broadcast route.
+     */
+    public void stop() {
+        if (rb != null) { 
+            try {
+                cc.removeRoute(rb.toString());
+            } catch (Exception e) {
+                log.error("Could not remove route " + rb + " " + e);
+            }
+        }
+    }
+
+    /**
+     * Sets the CamelContext for the route.
+     * 
+     * @param cc the CamelContext for the route.
+     */
+    public void setCamelContext(CamelContext cc) {
+        this.cc = cc;
+    }
+
+    /**
+     * Sets the input stream for the route.
+     * 
+     * @param inputStream the input stream for the route
+     */
+    public void setInputStream(String inputStream) {
+        this.inputStream = inputStream;
+    }
+
+    /**
+     * Sets the message recipients for the route.
+     * 
+     * @param messageRecipients the message recipients for the route
+     */
+    public void setMessageRecipients(String messageRecipients) {
+        this.messageRecipients = messageRecipients;
+    }
+}

--- a/umd-fcrepo-broadcast/src/main/java/edu/umd/lib/fcrepo/camel/broadcast/BroadcastFactory.java
+++ b/umd-fcrepo-broadcast/src/main/java/edu/umd/lib/fcrepo/camel/broadcast/BroadcastFactory.java
@@ -1,0 +1,168 @@
+
+package edu.umd.lib.fcrepo.camel.broadcast;
+
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
+
+import org.apache.camel.CamelContext;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.cm.ConfigurationException;
+import org.osgi.service.cm.ManagedServiceFactory;
+import org.osgi.util.tracker.ServiceTracker;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * ManagedServiceFactory implementation for creating BroadcastDispatcher instances.
+ * 
+ * This implementation is inspired by the code in Chapter 2, Recipe 6 of
+ * 
+ *  Nierbeck A., "Apache Karaf Cookbook : Over 60 Recipes to Help You Get the Most Out of Apache Karaf Deployments.",
+ *  Birmingham, UK: Packt Pub; 2014.
+ */
+public class BroadcastFactory implements ManagedServiceFactory {
+  public final static String INPUT_STREAM = "input.stream";
+  public final static String MESSAGE_RECIPIENTS = "message.recipients";
+
+   private BundleContext bundleContext;
+   private CamelContext camelContext;
+   private ServiceRegistration registration;
+   private ServiceTracker tracker;
+   private Logger log = LoggerFactory.getLogger(BroadcastFactory.class);
+   private String configurationPid;
+   private Map<String, BroadcastDispatcher> dispatchEngines = Collections.synchronizedMap(new HashMap<String, BroadcastDispatcher>());
+    
+   /**
+    * Override ManagedServiceFactory interfaces.
+    */
+   @Override
+   public String getName() {
+       return configurationPid;
+   }
+
+   @Override
+   public void updated(String pid, Dictionary<String, ?> dict) throws ConfigurationException { 
+       log.info("updated " + pid + " with " + dict.toString());
+       BroadcastDispatcher engine = null;
+
+       if (dispatchEngines.containsKey(pid)) {
+           engine = dispatchEngines.get(pid);
+
+           if (engine != null) {
+               destroyEngine(engine);
+           }
+           dispatchEngines.remove(pid);
+       }
+
+       String inputStream = getDictionaryEntry(dict, INPUT_STREAM);
+       String messageRecipients = getDictionaryEntry(dict, MESSAGE_RECIPIENTS);
+
+       log.debug("inputStream: " + inputStream);
+       log.debug("messageRecipents: " + messageRecipients);
+       //Configuration was verified above, now create engine.
+       engine = new BroadcastDispatcher();
+       engine.setCamelContext(camelContext);
+       engine.setInputStream(inputStream);
+       engine.setMessageRecipients(messageRecipients);
+       
+       dispatchEngines.put(pid, engine);
+       log.debug("Start the engine...");
+       engine.start();
+   }
+    
+   @Override
+   public void deleted(String pid) {
+       if (dispatchEngines.containsKey(pid)) {
+         BroadcastDispatcher engine = dispatchEngines.get(pid);
+
+           if (engine != null) {
+               destroyEngine(engine);
+           }
+           dispatchEngines.remove(pid);
+       }
+       log.info("deleted " + pid);
+   }
+
+   /**
+    * Retrieve the value at the given key from the given Dictionary, or throw a ConfigurationException
+    * if the key is not found or the value is the empty string.
+    * 
+    * @param dict the Dictionary to retrieve the value from
+    * @param key the key to retrieve the value of
+    * @return the String value at the given key
+    * @throws ConfigurationException if the key is not found, or the value is an empty string. 
+    */
+   protected String getDictionaryEntry(Dictionary<String, ?> dict, String key)
+     throws ConfigurationException {
+     String value = (String) dict.get(key);
+     if ((value != null) && (!value.trim().isEmpty())) {
+         log.debug(key + " set to " + value);
+         return value;
+     } else {
+       throw new ConfigurationException(key, "Key is missing or empty");
+     }
+   }
+
+   private void destroyEngine(BroadcastDispatcher engine) {
+       engine.stop();
+   }
+
+   /**
+    * Initialization method called via the blueprint
+    */
+   public void init() {
+       log.info("Starting " + this.getName());
+       Dictionary<String, String> servProps = new Hashtable<String, String>();
+       servProps.put(Constants.SERVICE_PID, configurationPid);
+       registration = bundleContext.registerService(ManagedServiceFactory.class.getName(), this, servProps);
+       tracker = new ServiceTracker(bundleContext, ConfigurationAdmin.class.getName(), null);
+       tracker.open();
+       log.info("Started " + this.getName());
+   }
+
+   /**
+    * Destroy method called via the blueprint
+    */
+   public void destroy() {
+       log.info("Destroying broadcast factory " + configurationPid);
+       registration.unregister();
+       tracker.close();
+   }
+
+   /**
+    * Sets the configuration pid from the blueprint
+    * 
+    * @param configurationPid the configuration pid from the blueprint
+    */
+   public void setConfigurationPid(String configurationPid) {
+       this.configurationPid = configurationPid;
+   }
+
+   /**
+    * Sets the bundle context from the blueprint
+    * 
+    * @param bundleContext the bundle context from the blueprint
+    */
+   public void setBundleContext(BundleContext bundleContext) {
+       this.bundleContext = bundleContext;
+   }
+
+   /**
+    * Sets the Camel context from the blueprint
+    * 
+    * @param camelContext the Camel context from the blueprint
+    */
+   public void setCamelContext(CamelContext camelContext) {
+       this.camelContext = camelContext;
+   }
+}
+
+

--- a/umd-fcrepo-broadcast/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/umd-fcrepo-broadcast/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+       xmlns:camel="http://camel.apache.org/schema/blueprint"
+       xsi:schemaLocation="
+       http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+       http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
+
+  <cm:property-placeholder persistent-id="edu.umd.lib.fcrepo.camel.broadcast" update-strategy="reload">
+      <cm:default-properties>
+        <cm:property name="edu.umd.lib.fcrepo.camel.broadcast.pid" value="edu.umd.lib.fcrepo.camel.broadcast"/>
+      </cm:default-properties>
+  </cm:property-placeholder>
+
+  <camelContext id="UmdFcrepoBroadcast" xmlns="http://camel.apache.org/schema/blueprint" autoStartup="true">
+  </camelContext>
+
+  <bean id="broadcast" class="edu.umd.lib.fcrepo.camel.broadcast.BroadcastFactory" init-method="init" destroy-method="destroy">
+    <property name="bundleContext" ref="blueprintBundleContext"/>
+    <property name="configurationPid" value="${edu.umd.lib.fcrepo.camel.broadcast.pid}"/>
+    <property name="camelContext" ref="UmdFcrepoBroadcast"/>
+  </bean>
+
+</blueprint>

--- a/umd-features/pom.xml
+++ b/umd-features/pom.xml
@@ -48,6 +48,11 @@
             <artifactId>umd-fcrepo-batch-ldcache-file</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>edu.umd.lib.fcrepo</groupId>
+            <artifactId>umd-fcrepo-broadcast</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/umd-features/src/main/resources/features.xml
+++ b/umd-features/src/main/resources/features.xml
@@ -45,4 +45,13 @@
     <configfile finalname="/etc/edu.umd.lib.fcrepo.camel.ldcache.file.cfg">mvn:edu.umd.lib.fcrepo/umd-fcrepo-batch-ldcache-file/${project.version}/cfg/configuration</configfile>
   </feature>
 
+  <feature name="umd-fcrepo-broadcast" version="${project.version}">
+    <details>Installs the UMD broadcast service.</details>
+
+    <bundle>mvn:edu.umd.lib.fcrepo/umd-fcrepo-broadcast/${project.version}</bundle>
+<!-- 
+    <configfile finalname="/etc/edu.umd.lib.fcrepo.camel.broadcast.cfg">mvn:edu.umd.lib.fcrepo/umd-fcrepo-broadcast/${project.version}/cfg/configuration</configfile>
+     -->
+  </feature>
+
 </features>


### PR DESCRIPTION
Added "umd-fcrepo-broadcast" component that allows multiple broadcast routes to be
created.

https://issues.umd.edu/browse/LIBFCREPO-448