### PR TITLE
LIBFCREPO-464. Support CONSTRUCT queries.

### DIFF
--- a/umd-fcrepo-sparql-query/README.md
+++ b/umd-fcrepo-sparql-query/README.md
@@ -2,14 +2,15 @@
 
 * Runs a SPARQL query on the messages from the "input.stream" queue/topic
 sending the query results to the "output.stream" queue/topic.
-* Multiple service instances can be created
+* Multiple service instances can be created.
+* Supports `SELECT` and `CONSTRUCT` SPARQL queries.
 * The format of the SPARQL query results is configurable.
 
 ## Configuration
 
 A service instance is created by adding an
-"edu.umd.lib.fcrepo.camel.sparql.query-[ROUTE_IDENTIFIER].cfg" file
-into the Karaf etc/ directory, where [ROUTE_IDENTIFIER] is a unique name for
+`edu.umd.lib.fcrepo.camel.sparql.query-[ROUTE_IDENTIFIER.cfg` file
+into the Karaf etc/ directory, where `[ROUTE_IDENTIFIER]` is a unique name for
 the route.
 
 ### Example Configuration:
@@ -86,11 +87,15 @@ This line includes each of the variables in the SPARQL SELECT statement
 (a timestamp, the URI of the checked file, the event outcomes (grouped together
 and separated by a "|"), the file size, and the message digest).
 
-### Result Formats
+### Supported Result Formats
 
-The "results.format" property will accept:
+#### `SELECT` Queries
 
-* Any names in the org.apache.jena.sparql.resultset.ResultsFormat class (i.e.,
+* Any names in the [org.apache.jena.sparql.resultset.ResultsFormat](https://jena.apache.org/documentation/javadoc/arq/org/apache/jena/sparql/resultset/ResultsFormat.html) class (i.e.,
 "csv", "tuples", "turtle", "n-triples", etc.)
-* The custom "csvWithoutHeader" value, which works like the "cvs" format in the
+* The custom "csvWithoutHeader" value, which works like the "csv" format in the
 Jena ResultsFormat format class, only without printing a header row.
+
+#### `CONSTRUCT` Queries
+
+* Any names accepted by the [org.apache.jena.rdf.model.Model.write](https://jena.apache.org/documentation/javadoc/jena/org/apache/jena/rdf/model/Model.html#write-java.io.OutputStream-java.lang.String-) method (i.e., "turtle", "n-triples", etc.)

--- a/umd-fcrepo-sparql-query/src/test/java/edu/umd/lib/fcrepo/camel/sparql/query/SparqlQueryProcessorTest.java
+++ b/umd-fcrepo-sparql-query/src/test/java/edu/umd/lib/fcrepo/camel/sparql/query/SparqlQueryProcessorTest.java
@@ -3,18 +3,50 @@ package edu.umd.lib.fcrepo.camel.sparql.query;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
 import org.junit.Before;
 import org.junit.Test;
 
 public class SparqlQueryProcessorTest {
+  public static final Property RDF_TYPE = ResourceFactory
+      .createProperty("http://www.w3.org/1999/02/22-rdf-syntax-ns#type");
+  public static final String PREMIS_NS = "http://www.loc.gov/premis/rdf/v1#";
+  public static final Resource EVENT = ResourceFactory.createResource(PREMIS_NS + "Event");
+  public static final Resource EVENT_OUTCOME_DETAIL = ResourceFactory.createResource(PREMIS_NS + "EventOutcomeDetail");
+  public static final Resource FIXITY = ResourceFactory.createResource(PREMIS_NS + "Fixity");
+  public static final Property HAS_EVENT_TYPE = ResourceFactory.createProperty(PREMIS_NS + "hasEventType");
+  public static final Property HAS_EVENT_RELATED_OBJECT = ResourceFactory
+      .createProperty(PREMIS_NS + "hasEventRelatedObject");
+  public static final Property HAS_EVENT_DATE_TIME = ResourceFactory.createProperty(PREMIS_NS + "hasEventDateTime");
+  public static final Property HAS_EVENT_OUTCOME = ResourceFactory.createProperty(PREMIS_NS + "hasEventOutcome");
+  public static final Property HAS_EVENT_OUTCOME_DETAIL = ResourceFactory
+      .createProperty(PREMIS_NS + "hasEventOutcomeDetail");
+  public static final Property HAS_MESSAGE_DIGEST = ResourceFactory.createProperty(PREMIS_NS + "hasMessageDigest");
+  public static final Property HAS_MESSAGE_DIGEST_ALGORITHM = ResourceFactory
+      .createProperty(PREMIS_NS + "hasMessageDigestAlgorithm");
+  public static final Property HAS_SIZE = ResourceFactory.createProperty(PREMIS_NS + "hasSize");
+  public static final Resource EXTERNAL_EVENT = ResourceFactory
+      .createResource("http://fedora.info/definitions/v4/audit#ExternalEvent");
+  public static final Resource INSTANTANEOUS_EVENT = ResourceFactory
+      .createResource("http://www.w3.org/ns/prov#InstantaneousEvent");
+  public static final Resource PASSED = ResourceFactory.createResource("http://www.w3.org/ns/earl#passed");
+  public static final Resource FAILED = ResourceFactory.createResource("http://www.w3.org/ns/earl#failed");
+
   private String query;
+  private String constructQuery;
 
   @Before
   public void setUp() {
@@ -29,6 +61,36 @@ public class SparqlQueryProcessorTest {
         "        bind( xsd:integer(?_size) as ?size) ",
         "      } ",
         "      group by ?uri ?size ?messageDigest");
+
+    constructQuery = String.join("\n",
+        "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>",
+        "PREFIX premis: <http://www.loc.gov/premis/rdf/v1#>",
+        "PREFIX audit: <http://fedora.info/definitions/v4/audit#>",
+        "PREFIX prov: <http://www.w3.org/ns/prov#>",
+        "PREFIX earl: <http://www.w3.org/ns/earl#>",
+        "CONSTRUCT {",
+        "  ?audit a premis:Event, audit:ExternalEvent, prov:InstantaneousEvent ;",
+        "  premis:hasEventType <http://id.loc.gov/vocabulary/preservation/eventType/fix> ;",
+        "  premis:hasEventRelatedObject ?target ;",
+        "  premis:hasEventDateTime ?now ;",
+        "  premis:hasEventOutcome ?outcome_term ;",
+        "  premis:hasEventOutcomeDetail ?s .",
+        "  ?s ?p ?o .",
+        "}",
+        "WHERE {",
+        "  {",
+        "    SELECT ?s ?p ?o",
+        "      (uri(strbefore(str(?s), \"#\")) AS ?target)",
+        "      (now() as ?now)",
+        "      (uri(concat(\"https://fcrepolocal/audit/\", str(?uuid))) as ?audit)",
+        "      (if(?outcome = \"SUCCESS\", earl:passed, earl:failed) as ?outcome_term)",
+        "    WHERE {",
+        "      ?s ?p ?o",
+        "      { SELECT ?s (uuid() as ?uuid) WHERE { ?s a premis:Fixity } LIMIT 1 }",
+        "      { SELECT ?outcome WHERE { ?x premis:hasEventOutcome ?outcome } LIMIT 1 }",
+        "    }",
+        "  }",
+        "}");
   }
 
   @Test
@@ -77,5 +139,80 @@ public class SparqlQueryProcessorTest {
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidResultFormat() {
     SparqlQueryProcessor processor = new SparqlQueryProcessor(query, "NOT_A_RESULT_FORMAT_NAME");
+  }
+
+  @Test
+  public void testConstructFixitySuccess() throws FileNotFoundException {
+    File file = new File(getClass().getResource("/fixity-success.rdf").getFile());
+    InputStream in = new FileInputStream(file);
+  
+    SparqlQueryProcessor processor = new SparqlQueryProcessor(constructQuery, "N-Triples");
+    String output = processor.executeQuery(in);
+    InputStream rdf = new ByteArrayInputStream(output.getBytes());
+  
+    Model model = ModelFactory.createDefaultModel();
+    model.read(rdf, "", "N-Triples");
+  
+    Resource fixityResult = model.createResource(
+        "https://fcrepolocal/fcrepo/rest/pcdm/fc/75/16/91/fc751691-b55e-46d9-b7da-a5c7bf3f40f3#fixity/1512758476451");
+  
+    List<Resource> subjects = model.listResourcesWithProperty(RDF_TYPE, EVENT).toList();
+    Resource auditEvent = subjects.get(0);
+  
+    assertTrue(model.contains(auditEvent, RDF_TYPE, EVENT));
+    assertTrue(model.contains(auditEvent, RDF_TYPE, EXTERNAL_EVENT));
+    assertTrue(model.contains(auditEvent, RDF_TYPE, INSTANTANEOUS_EVENT));
+    assertTrue(model.contains(auditEvent, HAS_EVENT_TYPE,
+        model.createResource("http://id.loc.gov/vocabulary/preservation/eventType/fix")));
+    assertTrue(model.contains(auditEvent, HAS_EVENT_RELATED_OBJECT,
+        model.createResource("https://fcrepolocal/fcrepo/rest/pcdm/fc/75/16/91/fc751691-b55e-46d9-b7da-a5c7bf3f40f3")));
+    assertTrue(model.contains(auditEvent, HAS_EVENT_OUTCOME, PASSED));
+    assertTrue(model.contains(auditEvent, HAS_EVENT_DATE_TIME));
+    assertTrue(model.contains(auditEvent, HAS_EVENT_OUTCOME_DETAIL, fixityResult));
+    assertTrue(model.contains(fixityResult, RDF_TYPE, EVENT_OUTCOME_DETAIL));
+    assertTrue(model.contains(fixityResult, RDF_TYPE, FIXITY));
+    assertTrue(model.contains(fixityResult, HAS_EVENT_OUTCOME, "SUCCESS"));
+    assertTrue(model.contains(fixityResult, HAS_MESSAGE_DIGEST,
+        model.createResource("urn:sha1:b267e0490a0985ff7a721858b01e354a12e63cac")));
+    assertTrue(model.contains(fixityResult, HAS_MESSAGE_DIGEST_ALGORITHM, "SHA-1"));
+    assertTrue(model.contains(fixityResult, HAS_SIZE, model.createTypedLiteral(32277709)));
+  }
+
+  @Test
+  public void testConstructFixityFailure() throws FileNotFoundException {
+    File file = new File(getClass().getResource("/fixity-failure.rdf").getFile());
+    InputStream in = new FileInputStream(file);
+  
+    SparqlQueryProcessor processor = new SparqlQueryProcessor(constructQuery, "N-Triples");
+    String output = processor.executeQuery(in);
+    InputStream rdf = new ByteArrayInputStream(output.getBytes());
+  
+    Model model = ModelFactory.createDefaultModel();
+    model.read(rdf, "", "N-Triples");
+  
+    Resource fixityResult = model.createResource(
+        "https://fcrepolocal/fcrepo/rest/pcdm/fc/75/16/91/fc751691-b55e-46d9-b7da-a5c7bf3f40f3#fixity/1512758673019");
+  
+    List<Resource> subjects = model.listResourcesWithProperty(RDF_TYPE, EVENT).toList();
+    Resource auditEvent = subjects.get(0);
+  
+    assertTrue(model.contains(auditEvent, RDF_TYPE, EVENT));
+    assertTrue(model.contains(auditEvent, RDF_TYPE, EXTERNAL_EVENT));
+    assertTrue(model.contains(auditEvent, RDF_TYPE, INSTANTANEOUS_EVENT));
+    assertTrue(model.contains(auditEvent, HAS_EVENT_TYPE,
+        model.createResource("http://id.loc.gov/vocabulary/preservation/eventType/fix")));
+    assertTrue(model.contains(auditEvent, HAS_EVENT_RELATED_OBJECT,
+        model.createResource("https://fcrepolocal/fcrepo/rest/pcdm/fc/75/16/91/fc751691-b55e-46d9-b7da-a5c7bf3f40f3")));
+    assertTrue(model.contains(auditEvent, HAS_EVENT_OUTCOME, FAILED));
+    assertTrue(model.contains(auditEvent, HAS_EVENT_DATE_TIME));
+    assertTrue(model.contains(auditEvent, HAS_EVENT_OUTCOME_DETAIL, fixityResult));
+    assertTrue(model.contains(fixityResult, RDF_TYPE, EVENT_OUTCOME_DETAIL));
+    assertTrue(model.contains(fixityResult, RDF_TYPE, FIXITY));
+    assertTrue(model.contains(fixityResult, HAS_EVENT_OUTCOME, "BAD_CHECKSUM"));
+    assertTrue(model.contains(fixityResult, HAS_EVENT_OUTCOME, "BAD_SIZE"));
+    assertTrue(model.contains(fixityResult, HAS_MESSAGE_DIGEST,
+        model.createResource("urn:sha1:63edda4d89dc93b578c44013cada91aab492614b")));
+    assertTrue(model.contains(fixityResult, HAS_MESSAGE_DIGEST_ALGORITHM, "SHA-1"));
+    assertTrue(model.contains(fixityResult, HAS_SIZE, model.createTypedLiteral(32277713)));
   }
 }


### PR DESCRIPTION
Throws an IllegalArgumentException if the query type is neither SELECT nor CONSTRUCT. It also throws an IllegalArgumentException if the model writer cannot write to the format name given in result.format.

https://issues.umd.edu/browse/LIBFCREPO-464