### PR TITLE
LIBFCREPO-438. Added umd-fcrepo-triplestore route.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <module>umd-features</module>
         <module>umd-fcrepo-broadcast</module>
         <module>umd-fcrepo-sparql-query</module>
+        <module>umd-fcrepo-triplestore</module>
     </modules>
 
     <dependencyManagement>

--- a/umd-fcrepo-triplestore/README.md
+++ b/umd-fcrepo-triplestore/README.md
@@ -1,0 +1,26 @@
+# UMD Fcrepo Triplestore
+
+* Takes the message body from an "input.stream" queue/topic and sends it
+  as a SPARQL Update `INSERT DATA { ... }` request to a triplestore via HTTP.
+* Multiple service instances can be created
+
+## Configuration
+
+A service instance is created by adding an `edu.umd.lib.fcrepo.camel.triplestore-[ROUTE_IDENTIFIER].cfg`
+into the Karaf etc/ directory, where `[ROUTE_IDENTIFIER]` is a unique name for
+the route.
+
+### Example Configuration
+
+```
+# Which queue/topic to listen to
+input.stream=activemq:queue:triplestore.audit.data
+
+# Triplestore URI that can accept HTTP POST requests
+# with Content-Type: application/sparql-update
+triplestore.baseUrl=http://example.com/fuseki/dataset/update
+
+# In the event of failure, the maximum number of times a redelivery
+# will be attempted.
+error.maxRedeliveries=10
+```

--- a/umd-fcrepo-triplestore/pom.xml
+++ b/umd-fcrepo-triplestore/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" 
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <!--
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>edu.umd.lib.fcrepo</groupId>
+        <artifactId>umd-fcrepo-camel-extensions</artifactId>
+        <version>1.3.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>umd-fcrepo-triplestore</artifactId>
+    <packaging>bundle</packaging>
+
+    <name>UMD Fcrepo Triplestore</name>
+    <description>UMD Fcrepo Triplestore Project.</description>
+
+    <properties>
+        <osgi.import.packages>
+            *
+        </osgi.import.packages>
+        <osgi.export.packages>
+            edu.umd.lib.fcrepo.camel.triplestore*;version=${project.version}
+        </osgi.export.packages>
+    </properties>
+
+    <dependencies>
+        <!-- OSGI -->
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.compendium</artifactId>
+        </dependency>
+
+        <!-- Apache Camel -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-core</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/umd-fcrepo-triplestore/src/main/java/edu/umd/lib/fcrepo/camel/triplestore/TriplestoreFactory.java
+++ b/umd-fcrepo-triplestore/src/main/java/edu/umd/lib/fcrepo/camel/triplestore/TriplestoreFactory.java
@@ -1,0 +1,169 @@
+
+package edu.umd.lib.fcrepo.camel.triplestore;
+
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
+
+import org.apache.camel.CamelContext;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.cm.ConfigurationException;
+import org.osgi.service.cm.ManagedServiceFactory;
+import org.osgi.util.tracker.ServiceTracker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * ManagedServiceFactory implementation for creating TriplestoreRouter
+ * instances.
+ *
+ * This implementation is inspired by the code in Chapter 2, Recipe 6 of
+ *
+ * Nierbeck A., "Apache Karaf Cookbook : Over 60 Recipes to Help You Get the
+ * Most Out of Apache Karaf Deployments.", Birmingham, UK: Packt Pub; 2014.
+ */
+public class TriplestoreFactory implements ManagedServiceFactory {
+  public final static String INPUT_STREAM = "input.stream";
+  public final static String TRIPLESTORE_BASE_URL = "triplestore.baseUrl";
+  public final static String ERROR_MAX_REDELIVERIES = "error.maxRedeliveries";
+
+  private BundleContext bundleContext;
+  private CamelContext camelContext;
+  private ServiceRegistration registration;
+  private ServiceTracker tracker;
+  private Logger log = LoggerFactory.getLogger(TriplestoreFactory.class);
+  private String configurationPid;
+  private Map<String, TriplestoreRouter> dispatchEngines = Collections.synchronizedMap(new HashMap<String, TriplestoreRouter>());
+
+  /**
+   * Override ManagedServiceFactory interfaces.
+   */
+  @Override
+  public String getName() {
+    return configurationPid;
+  }
+
+  @Override
+  public void updated(String pid, Dictionary<String, ?> dict) throws ConfigurationException {
+    log.info("updated " + pid + " with " + dict.toString());
+    TriplestoreRouter engine = null;
+
+    if (dispatchEngines.containsKey(pid)) {
+      engine = dispatchEngines.get(pid);
+
+      if (engine != null) {
+        destroyEngine(engine);
+      }
+      dispatchEngines.remove(pid);
+    }
+
+    String inputStream = getDictionaryEntry(dict, INPUT_STREAM);
+    String triplestoreBaseUrl = getDictionaryEntry(dict, TRIPLESTORE_BASE_URL);
+    String maxRedeliveries = getDictionaryEntry(dict, ERROR_MAX_REDELIVERIES);
+
+    log.debug("inputStream: " + inputStream);
+    log.debug("triplestoreBaseUrl: " + triplestoreBaseUrl);
+    log.debug("errorMaxRedeliveries: " + maxRedeliveries);
+    //Configuration was verified above, now create engine.
+    engine = new TriplestoreRouter();
+    engine.setCamelContext(camelContext);
+    engine.setInputStream(inputStream);
+    engine.setTriplestoreBaseUrl(triplestoreBaseUrl);
+    engine.setMaxRedeliveries(Integer.parseInt(maxRedeliveries));
+
+    dispatchEngines.put(pid, engine);
+    log.debug("Start the engine...");
+    engine.start();
+  }
+
+  @Override
+  public void deleted(String pid) {
+    if (dispatchEngines.containsKey(pid)) {
+      TriplestoreRouter engine = dispatchEngines.get(pid);
+
+      if (engine != null) {
+        destroyEngine(engine);
+      }
+      dispatchEngines.remove(pid);
+    }
+    log.info("deleted " + pid);
+  }
+
+  /**
+   * Retrieve the value at the given key from the given Dictionary, or throw a ConfigurationException
+   * if the key is not found or the value is the empty string.
+   *
+   * @param dict the Dictionary to retrieve the value from
+   * @param key the key to retrieve the value of
+   * @return the String value at the given key
+   * @throws ConfigurationException if the key is not found, or the value is an empty string.
+   */
+  protected String getDictionaryEntry(Dictionary<String, ?> dict, String key)
+      throws ConfigurationException {
+    String value = (String) dict.get(key);
+    if ((value != null) && (!value.trim().isEmpty())) {
+      log.debug(key + " set to " + value);
+      return value;
+    } else {
+      throw new ConfigurationException(key, "Key is missing or empty");
+    }
+  }
+
+  private void destroyEngine(TriplestoreRouter engine) {
+    engine.stop();
+  }
+
+  /**
+   * Initialization method called via the blueprint
+   */
+  public void init() {
+    log.info("Starting " + this.getName());
+    Dictionary<String, String> servProps = new Hashtable<String, String>();
+    servProps.put(Constants.SERVICE_PID, configurationPid);
+    registration = bundleContext.registerService(ManagedServiceFactory.class.getName(), this, servProps);
+    tracker = new ServiceTracker(bundleContext, ConfigurationAdmin.class.getName(), null);
+    tracker.open();
+    log.info("Started " + this.getName());
+  }
+
+  /**
+   * Destroy method called via the blueprint
+   */
+  public void destroy() {
+    log.info("Destroying triplestore factory " + configurationPid);
+    registration.unregister();
+    tracker.close();
+  }
+
+  /**
+   * Sets the configuration pid from the blueprint
+   *
+   * @param configurationPid the configuration pid from the blueprint
+   */
+  public void setConfigurationPid(String configurationPid) {
+    this.configurationPid = configurationPid;
+  }
+
+  /**
+   * Sets the bundle context from the blueprint
+   *
+   * @param bundleContext the bundle context from the blueprint
+   */
+  public void setBundleContext(BundleContext bundleContext) {
+    this.bundleContext = bundleContext;
+  }
+
+  /**
+   * Sets the Camel context from the blueprint
+   *
+   * @param camelContext the Camel context from the blueprint
+   */
+  public void setCamelContext(CamelContext camelContext) {
+    this.camelContext = camelContext;
+  }
+}

--- a/umd-fcrepo-triplestore/src/main/java/edu/umd/lib/fcrepo/camel/triplestore/TriplestoreRouter.java
+++ b/umd-fcrepo-triplestore/src/main/java/edu/umd/lib/fcrepo/camel/triplestore/TriplestoreRouter.java
@@ -1,0 +1,143 @@
+package edu.umd.lib.fcrepo.camel.triplestore;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.apache.camel.builder.RouteBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A triplestore router, typically created by a TriplestoreFactory. It expects
+ * N-Triples formatted RDF as the body of the input message, and sends that RDF,
+ * wrapped in a SPARQL <code>INSERT DATA { ... }</code> statement, in a POST
+ * request to the http: or https: URL set in <code>triplestore.baseUrl</code>.
+ * The Content-Type of that request is "application/sparql-update".
+ *
+ * This implementation is inspired by the code in Chapter 2, Recipe 6 of
+ *
+ * Nierbeck A., "Apache Karaf Cookbook : Over 60 Recipes to Help You Get the
+ * Most Out of Apache Karaf Deployments.", Birmingham, UK: Packt Pub; 2014.
+ */
+public class TriplestoreRouter {
+
+  private String inputStream;
+  private String triplestoreBaseUrl;
+  private int maxRedeliveries;
+  private RouteBuilder rb;
+  private CamelContext cc;
+
+  private Logger log = LoggerFactory.getLogger(TriplestoreRouter.class);
+
+  public TriplestoreRouter() { }
+
+  /**
+   * Builds and starts the triplestore route.
+   */
+  public void start() {
+    try {
+      rb = buildTriplestoreRouter();
+      log.info("Route " + rb + " starting...");
+      cc.start();
+      cc.addRoutes(rb);
+    } catch (Exception ex) {
+      log.error("Could not process Triplestore " + ex);
+    }
+  }
+
+  /**
+   * Returns a RouteBuilder, using the values from the instance variables
+   *
+   * @return
+   * @throws Exception
+   */
+  protected RouteBuilder buildTriplestoreRouter() throws Exception {
+    return new RouteBuilder() {
+      @Override
+      public void configure() throws Exception {
+
+        /**
+         * A generic error handler (specific to this RouteBuilder)
+         */
+        onException(Exception.class)
+        .maximumRedeliveries(maxRedeliveries)
+        .log("Event Routing Error: ${routeId}");
+
+        from(inputStream)
+        .routeId("Triplestore " + inputStream)
+        .description("Send RDF triples to a triplestore.")
+        .process(new SparqlInsertDataWrapper())
+        .to(triplestoreBaseUrl + "?useSystemProperties=true")
+        .to("file:/tmp?fileName=audit.sparql");
+      }
+    };
+  }
+
+  /**
+   * Stops the triplestore route.
+   */
+  public void stop() {
+    if (rb != null) {
+      try {
+        cc.removeRoute(rb.toString());
+      } catch (Exception e) {
+        log.error("Could not remove route " + rb + " " + e);
+      }
+    }
+  }
+
+  /**
+   * Sets the CamelContext for the route.
+   *
+   * @param cc the CamelContext for the route.
+   */
+  public void setCamelContext(CamelContext cc) {
+    this.cc = cc;
+  }
+
+  /**
+   * Sets the input stream for the route.
+   *
+   * @param inputStream the input stream for the route
+   */
+  public void setInputStream(String inputStream) {
+    this.inputStream = inputStream;
+  }
+
+  /**
+   * Sets the message recipients for the route.
+   *
+   * @param triplestoreBaseUrl the message recipients for the route
+   */
+  public void setTriplestoreBaseUrl(String triplestoreBaseUrl) {
+    this.triplestoreBaseUrl = triplestoreBaseUrl;
+  }
+
+  /**
+   * Sets the maximum number of redeliveries on error for the route
+   *
+   * @param maxRedeliveries
+   */
+  public void setMaxRedeliveries(int maxRedeliveries) {
+    this.maxRedeliveries = maxRedeliveries;
+  }
+
+  /**
+   * Simple processor whose only function is to wrap the incoming message body
+   * in <code>INSERT DATA { ... }</code> and set the Content-Type and HTTP
+   * method headers to "application/sparql-update" and "POST", respectively.
+   */
+  private class SparqlInsertDataWrapper implements Processor {
+
+    @Override
+    public void process(Exchange exchange) throws Exception {
+      Message in = exchange.getIn();
+      in.setHeader(Exchange.CONTENT_TYPE, "application/sparql-update");
+      in.setHeader(Exchange.HTTP_METHOD, "POST");
+      String rdf = (String) in.getBody();
+      in.setBody("INSERT DATA { " + rdf + " }");
+      log.debug((String) in.getBody());
+    }
+  }
+}

--- a/umd-fcrepo-triplestore/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/umd-fcrepo-triplestore/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+       xmlns:camel="http://camel.apache.org/schema/blueprint"
+       xsi:schemaLocation="
+       http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+       http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
+
+  <cm:property-placeholder persistent-id="edu.umd.lib.fcrepo.camel.triplestore" update-strategy="reload">
+      <cm:default-properties>
+        <cm:property name="edu.umd.lib.fcrepo.camel.triplestore.pid" value="edu.umd.lib.fcrepo.camel.triplestore"/>
+      </cm:default-properties>
+  </cm:property-placeholder>
+
+  <camelContext id="UmdFcrepoTriplestore" xmlns="http://camel.apache.org/schema/blueprint" autoStartup="true">
+  </camelContext>
+
+  <bean id="triplestore" class="edu.umd.lib.fcrepo.camel.triplestore.TriplestoreFactory" init-method="init" destroy-method="destroy">
+    <property name="bundleContext" ref="blueprintBundleContext"/>
+    <property name="configurationPid" value="${edu.umd.lib.fcrepo.camel.triplestore.pid}"/>
+    <property name="camelContext" ref="UmdFcrepoTriplestore"/>
+  </bean>
+  
+  <!--  borrowed from fcrepo-audit-triplestore; allows us to use http: and https: URIs in the
+        route destinations and have them interpreted as http4: Camel components -->
+  <bean id="http" class="org.apache.camel.component.http4.HttpComponent"/>
+  <bean id="https" class="org.apache.camel.component.http4.HttpComponent"/>
+
+</blueprint>

--- a/umd-features/src/main/resources/features.xml
+++ b/umd-features/src/main/resources/features.xml
@@ -57,4 +57,9 @@
     <bundle>mvn:edu.umd.lib.fcrepo/umd-fcrepo-sparql-query/${project.version}</bundle>
   </feature>
 
+  <feature name="umd-fcrepo-triplestore" version="${project.version}">
+    <details>Installs the UMD triplestore service.</details>
+
+    <bundle>mvn:edu.umd.lib.fcrepo/umd-fcrepo-triplestore/${project.version}</bundle>
+  </feature>
 </features>


### PR DESCRIPTION
The function of this route is to take N-Triples data, wrap it in a SPARQL Update INSERT DATA { ... } command and POST it to an HTTP URL as Content-Type: application/sparql-update.

https://issues.umd.edu/browse/LIBFCREPO-438