### PR TITLE
LIBFCREPO-478. Refactored classes for multiply instantiable Camel routes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <module>umd-fcrepo-sparql-query</module>
         <module>umd-fcrepo-triplestore</module>
         <module>umd-fcrepo-notification</module>
+        <module>umd-osgi-extensions</module>
     </modules>
 
     <dependencyManagement>

--- a/umd-fcrepo-broadcast/pom.xml
+++ b/umd-fcrepo-broadcast/pom.xml
@@ -61,7 +61,7 @@
         </dependency>
         
         <dependency>
-            <groupId>edu.umd.lib</groupId>
+            <groupId>edu.umd.lib.fcrepo</groupId>
             <artifactId>umd-osgi-extensions</artifactId>
             <version>${project.version}</version>
             <type>jar</type>

--- a/umd-fcrepo-broadcast/pom.xml
+++ b/umd-fcrepo-broadcast/pom.xml
@@ -59,6 +59,13 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core</artifactId>
         </dependency>
+        
+        <dependency>
+            <groupId>edu.umd.lib</groupId>
+            <artifactId>umd-osgi-extensions</artifactId>
+            <version>${project.version}</version>
+            <type>jar</type>
+        </dependency>
     </dependencies>
 
     <build>

--- a/umd-fcrepo-broadcast/src/main/java/edu/umd/lib/fcrepo/camel/broadcast/BroadcastDispatcher.java
+++ b/umd-fcrepo-broadcast/src/main/java/edu/umd/lib/fcrepo/camel/broadcast/BroadcastDispatcher.java
@@ -1,101 +1,81 @@
 package edu.umd.lib.fcrepo.camel.broadcast;
 
-import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import edu.umd.lib.osgi.service.AbstractManagedServiceInstance;
+
 /**
  * A broadcast service instance, typically created and controlled via the BroadcastFactory.
- * 
+ *
  * This implementation is inspired by the code in Chapter 2, Recipe 6 of
- * 
- *  Nierbeck A., "Apache Karaf Cookbook : Over 60 Recipes to Help You Get the Most Out of Apache Karaf Deployments.",
- *  Birmingham, UK: Packt Pub; 2014.
+ *
+ * Nierbeck A., "Apache Karaf Cookbook : Over 60 Recipes to Help You Get the Most Out of Apache Karaf Deployments.",
+ * Birmingham, UK: Packt Pub; 2014.
  */
-public class BroadcastDispatcher {
+public class BroadcastDispatcher extends AbstractManagedServiceInstance {
+  private Logger log = LoggerFactory.getLogger(BroadcastDispatcher.class);
 
-    private String inputStream;
-    private String messageRecipients;
-    private RouteBuilder rb;
-    private CamelContext cc;
+  private String inputStream;
+  private String messageRecipients;
 
-    private Logger log = LoggerFactory.getLogger(BroadcastDispatcher.class);
+  public BroadcastDispatcher() {
+  }
 
-    public BroadcastDispatcher() { }
+  /**
+   * Returns a RouteBuilder, using the values from the instance variables
+   *
+   * @return
+   * @throws Exception
+   */
+  @Override
+  protected RouteBuilder buildRoute() throws Exception {
+    return new RouteBuilder() {
+      @Override
+      public void configure() throws Exception {
+        from(inputStream)
+            .routeId("Broadcast " + inputStream)
+            .description("Broadcast messages from one queue/topic to other specified queues/topics.")
+            .log("Distributing message: ${headers[org.fcrepo.jms.timestamp]}: " +
+                "${headers[org.fcrepo.jms.identifier]}:${headers[org.fcrepo.jms.eventType]}")
+            .recipientList(simple(messageRecipients)).ignoreInvalidEndpoints();
+      }
+    };
+  }
 
-    /**
-     * Builds and starts the broadcast route.
-     */
-    public void start() {
-        try {
-            rb = buildBroadcastRouter();
-            log.info("Route " + rb + " starting..."); 
-            cc.start();
-            cc.addRoutes(rb);
-        } catch (Exception ex) {
-            log.error("Could not process Broadcast " + ex); 
-        }
-    }
+  /**
+   * Sets the input stream for the route.
+   *
+   * @param inputStream
+   *          the input stream for the route
+   */
+  public void setInputStream(String inputStream) {
+    this.inputStream = inputStream;
+  }
 
-    /**
-     * Returns a RouteBuilder, using the values from the instance variables
-     * 
-     * @return 
-     * @throws Exception
-     */
-    protected RouteBuilder buildBroadcastRouter() throws Exception {
-        return new RouteBuilder() {
-            @Override
-            public void configure() throws Exception {
-              from(inputStream)
-              .routeId("Broadcast " + inputStream)
-              .description("Broadcast messages from one queue/topic to other specified queues/topics.")
-              .log("Distributing message: ${headers[org.fcrepo.jms.timestamp]}: " +
-                      "${headers[org.fcrepo.jms.identifier]}:${headers[org.fcrepo.jms.eventType]}")
-              .recipientList(simple(messageRecipients)).ignoreInvalidEndpoints();
-            }
-        };
-    }
+  /**
+   * Sets the message recipients for the route.
+   *
+   * @param messageRecipients
+   *          the message recipients for the route
+   */
+  public void setMessageRecipients(String messageRecipients) {
+    this.messageRecipients = messageRecipients;
+  }
 
-    /**
-     * Stops the broadcast route.
-     */
-    public void stop() {
-        if (rb != null) { 
-            try {
-                cc.removeRoute(rb.toString());
-            } catch (Exception e) {
-                log.error("Could not remove route " + rb + " " + e);
-            }
-        }
-    }
-
-    /**
-     * Sets the CamelContext for the route.
-     * 
-     * @param cc the CamelContext for the route.
-     */
-    public void setCamelContext(CamelContext cc) {
-        this.cc = cc;
-    }
-
-    /**
-     * Sets the input stream for the route.
-     * 
-     * @param inputStream the input stream for the route
-     */
-    public void setInputStream(String inputStream) {
-        this.inputStream = inputStream;
-    }
-
-    /**
-     * Sets the message recipients for the route.
-     * 
-     * @param messageRecipients the message recipients for the route
-     */
-    public void setMessageRecipients(String messageRecipients) {
-        this.messageRecipients = messageRecipients;
-    }
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append(this.getClass().getName() + " [log=");
+    builder.append(log);
+    builder.append(", inputStream=");
+    builder.append(inputStream);
+    builder.append(", messageRecipients=");
+    builder.append(messageRecipients);
+    builder.append(", routeId=");
+    builder.append(routeId);
+    builder.append("]");
+    return builder.toString();
+  }
 }

--- a/umd-fcrepo-broadcast/src/main/java/edu/umd/lib/fcrepo/camel/broadcast/BroadcastDispatcher.java
+++ b/umd-fcrepo-broadcast/src/main/java/edu/umd/lib/fcrepo/camel/broadcast/BroadcastDispatcher.java
@@ -8,11 +8,6 @@ import edu.umd.lib.osgi.service.AbstractManagedServiceInstance;
 
 /**
  * A broadcast service instance, typically created and controlled via the BroadcastFactory.
- *
- * This implementation is inspired by the code in Chapter 2, Recipe 6 of
- *
- * Nierbeck A., "Apache Karaf Cookbook : Over 60 Recipes to Help You Get the Most Out of Apache Karaf Deployments.",
- * Birmingham, UK: Packt Pub; 2014.
  */
 public class BroadcastDispatcher extends AbstractManagedServiceInstance {
   private Logger log = LoggerFactory.getLogger(BroadcastDispatcher.class);

--- a/umd-fcrepo-broadcast/src/main/java/edu/umd/lib/fcrepo/camel/broadcast/BroadcastFactory.java
+++ b/umd-fcrepo-broadcast/src/main/java/edu/umd/lib/fcrepo/camel/broadcast/BroadcastFactory.java
@@ -1,168 +1,43 @@
 
 package edu.umd.lib.fcrepo.camel.broadcast;
 
-import java.util.Collections;
 import java.util.Dictionary;
-import java.util.HashMap;
-import java.util.Hashtable;
-import java.util.Map;
 
 import org.apache.camel.CamelContext;
-
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
-import org.osgi.framework.ServiceRegistration;
-import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.cm.ConfigurationException;
-import org.osgi.service.cm.ManagedServiceFactory;
-import org.osgi.util.tracker.ServiceTracker;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import edu.umd.lib.osgi.service.AbstractManagedServiceFactory;
+
 /**
  * ManagedServiceFactory implementation for creating BroadcastDispatcher instances.
- * 
+ *
  * This implementation is inspired by the code in Chapter 2, Recipe 6 of
- * 
- *  Nierbeck A., "Apache Karaf Cookbook : Over 60 Recipes to Help You Get the Most Out of Apache Karaf Deployments.",
- *  Birmingham, UK: Packt Pub; 2014.
+ *
+ * Nierbeck A., "Apache Karaf Cookbook : Over 60 Recipes to Help You Get the Most Out of Apache Karaf Deployments.",
+ * Birmingham, UK: Packt Pub; 2014.
  */
-public class BroadcastFactory implements ManagedServiceFactory {
+public class BroadcastFactory extends AbstractManagedServiceFactory<BroadcastDispatcher> {
+  private Logger log = LoggerFactory.getLogger(BroadcastFactory.class);
+
   public final static String INPUT_STREAM = "input.stream";
   public final static String MESSAGE_RECIPIENTS = "message.recipients";
 
-   private BundleContext bundleContext;
-   private CamelContext camelContext;
-   private ServiceRegistration registration;
-   private ServiceTracker tracker;
-   private Logger log = LoggerFactory.getLogger(BroadcastFactory.class);
-   private String configurationPid;
-   private Map<String, BroadcastDispatcher> dispatchEngines = Collections.synchronizedMap(new HashMap<String, BroadcastDispatcher>());
-    
-   /**
-    * Override ManagedServiceFactory interfaces.
-    */
-   @Override
-   public String getName() {
-       return configurationPid;
-   }
+  @Override
+  protected BroadcastDispatcher createServiceInstance(CamelContext camelContext,
+      Dictionary<String, ?> dict) throws ConfigurationException {
+    String messageRecipients = getDictionaryEntry(dict, MESSAGE_RECIPIENTS);
+    String inputStream = getDictionaryEntry(dict, INPUT_STREAM);
 
-   @Override
-   public void updated(String pid, Dictionary<String, ?> dict) throws ConfigurationException { 
-       log.info("updated " + pid + " with " + dict.toString());
-       BroadcastDispatcher engine = null;
+    log.debug("inputStream: " + inputStream);
+    log.debug("messageRecipents: " + messageRecipients);
 
-       if (dispatchEngines.containsKey(pid)) {
-           engine = dispatchEngines.get(pid);
-
-           if (engine != null) {
-               destroyEngine(engine);
-           }
-           dispatchEngines.remove(pid);
-       }
-
-       String inputStream = getDictionaryEntry(dict, INPUT_STREAM);
-       String messageRecipients = getDictionaryEntry(dict, MESSAGE_RECIPIENTS);
-
-       log.debug("inputStream: " + inputStream);
-       log.debug("messageRecipents: " + messageRecipients);
-       //Configuration was verified above, now create engine.
-       engine = new BroadcastDispatcher();
-       engine.setCamelContext(camelContext);
-       engine.setInputStream(inputStream);
-       engine.setMessageRecipients(messageRecipients);
-       
-       dispatchEngines.put(pid, engine);
-       log.debug("Start the engine...");
-       engine.start();
-   }
-    
-   @Override
-   public void deleted(String pid) {
-       if (dispatchEngines.containsKey(pid)) {
-         BroadcastDispatcher engine = dispatchEngines.get(pid);
-
-           if (engine != null) {
-               destroyEngine(engine);
-           }
-           dispatchEngines.remove(pid);
-       }
-       log.info("deleted " + pid);
-   }
-
-   /**
-    * Retrieve the value at the given key from the given Dictionary, or throw a ConfigurationException
-    * if the key is not found or the value is the empty string.
-    * 
-    * @param dict the Dictionary to retrieve the value from
-    * @param key the key to retrieve the value of
-    * @return the String value at the given key
-    * @throws ConfigurationException if the key is not found, or the value is an empty string. 
-    */
-   protected String getDictionaryEntry(Dictionary<String, ?> dict, String key)
-     throws ConfigurationException {
-     String value = (String) dict.get(key);
-     if ((value != null) && (!value.trim().isEmpty())) {
-         log.debug(key + " set to " + value);
-         return value;
-     } else {
-       throw new ConfigurationException(key, "Key is missing or empty");
-     }
-   }
-
-   private void destroyEngine(BroadcastDispatcher engine) {
-       engine.stop();
-   }
-
-   /**
-    * Initialization method called via the blueprint
-    */
-   public void init() {
-       log.info("Starting " + this.getName());
-       Dictionary<String, String> servProps = new Hashtable<String, String>();
-       servProps.put(Constants.SERVICE_PID, configurationPid);
-       registration = bundleContext.registerService(ManagedServiceFactory.class.getName(), this, servProps);
-       tracker = new ServiceTracker(bundleContext, ConfigurationAdmin.class.getName(), null);
-       tracker.open();
-       log.info("Started " + this.getName());
-   }
-
-   /**
-    * Destroy method called via the blueprint
-    */
-   public void destroy() {
-       log.info("Destroying broadcast factory " + configurationPid);
-       registration.unregister();
-       tracker.close();
-   }
-
-   /**
-    * Sets the configuration pid from the blueprint
-    * 
-    * @param configurationPid the configuration pid from the blueprint
-    */
-   public void setConfigurationPid(String configurationPid) {
-       this.configurationPid = configurationPid;
-   }
-
-   /**
-    * Sets the bundle context from the blueprint
-    * 
-    * @param bundleContext the bundle context from the blueprint
-    */
-   public void setBundleContext(BundleContext bundleContext) {
-       this.bundleContext = bundleContext;
-   }
-
-   /**
-    * Sets the Camel context from the blueprint
-    * 
-    * @param camelContext the Camel context from the blueprint
-    */
-   public void setCamelContext(CamelContext camelContext) {
-       this.camelContext = camelContext;
-   }
+    // Configuration was verified above, now create engine.
+    BroadcastDispatcher engine = new BroadcastDispatcher();
+    engine.setCamelContext(camelContext);
+    engine.setInputStream(inputStream);
+    engine.setMessageRecipients(messageRecipients);
+    return engine;
+  }
 }
-
-

--- a/umd-fcrepo-broadcast/src/main/java/edu/umd/lib/fcrepo/camel/broadcast/BroadcastFactory.java
+++ b/umd-fcrepo-broadcast/src/main/java/edu/umd/lib/fcrepo/camel/broadcast/BroadcastFactory.java
@@ -12,11 +12,6 @@ import edu.umd.lib.osgi.service.AbstractManagedServiceFactory;
 
 /**
  * ManagedServiceFactory implementation for creating BroadcastDispatcher instances.
- *
- * This implementation is inspired by the code in Chapter 2, Recipe 6 of
- *
- * Nierbeck A., "Apache Karaf Cookbook : Over 60 Recipes to Help You Get the Most Out of Apache Karaf Deployments.",
- * Birmingham, UK: Packt Pub; 2014.
  */
 public class BroadcastFactory extends AbstractManagedServiceFactory<BroadcastDispatcher> {
   private Logger log = LoggerFactory.getLogger(BroadcastFactory.class);

--- a/umd-fcrepo-sparql-query/README.md
+++ b/umd-fcrepo-sparql-query/README.md
@@ -9,7 +9,7 @@ sending the query results to the "output.stream" queue/topic.
 ## Configuration
 
 A service instance is created by adding an
-`edu.umd.lib.fcrepo.camel.sparql.query-[ROUTE_IDENTIFIER.cfg` file
+`edu.umd.lib.fcrepo.camel.sparql.query-[ROUTE_IDENTIFIER.cfg]` file
 into the Karaf etc/ directory, where `[ROUTE_IDENTIFIER]` is a unique name for
 the route.
 

--- a/umd-fcrepo-sparql-query/pom.xml
+++ b/umd-fcrepo-sparql-query/pom.xml
@@ -67,6 +67,13 @@
             <type>pom</type>
         </dependency>
         
+        <dependency>
+            <groupId>edu.umd.lib</groupId>
+            <artifactId>umd-osgi-extensions</artifactId>
+            <version>${project.version}</version>
+            <type>jar</type>
+        </dependency>
+        
         <!-- testing -->
         <dependency>
             <groupId>junit</groupId>

--- a/umd-fcrepo-sparql-query/pom.xml
+++ b/umd-fcrepo-sparql-query/pom.xml
@@ -68,10 +68,9 @@
         </dependency>
         
         <dependency>
-            <groupId>edu.umd.lib</groupId>
+            <groupId>edu.umd.lib.fcrepo</groupId>
             <artifactId>umd-osgi-extensions</artifactId>
             <version>${project.version}</version>
-            <type>jar</type>
         </dependency>
         
         <!-- testing -->

--- a/umd-fcrepo-sparql-query/src/main/java/edu/umd/lib/fcrepo/camel/sparql/query/SparqlQueryComponent.java
+++ b/umd-fcrepo-sparql-query/src/main/java/edu/umd/lib/fcrepo/camel/sparql/query/SparqlQueryComponent.java
@@ -1,9 +1,8 @@
 package edu.umd.lib.fcrepo.camel.sparql.query;
 
-import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import edu.umd.lib.osgi.service.AbstractManagedServiceInstance;
 
 /**
  * A component that runs a SPARQL query against the input, and sending the result to the specified output.
@@ -13,33 +12,13 @@ import org.slf4j.LoggerFactory;
  * "turtle", "n-triples" etc.), or a "csvWithoutHeader" format, which the same as the
  * "csv" format, except it does not print the header.
  */
-public class SparqlQueryComponent {
-
+public class SparqlQueryComponent extends AbstractManagedServiceInstance {
   private String inputStream;
   private String outputStream;
   private String query;
   private String resultsFormatName;
 
-  private RouteBuilder rb;
-  private CamelContext cc;
-
-  private Logger log = LoggerFactory.getLogger(SparqlQueryComponent.class);
-
   public SparqlQueryComponent() {
-  }
-
-  /**
-   * Builds and starts the SPARQL query route.
-   */
-  public void start() {
-    try {
-      rb = buildSparqlQueryProcessor();
-      log.info("Route " + rb + " starting...");
-      cc.start();
-      cc.addRoutes(rb);
-    } catch (Exception ex) {
-      log.error("Could not create SPARQL query route " + ex);
-    }
   }
 
   /**
@@ -49,7 +28,8 @@ public class SparqlQueryComponent {
    * @throws Exception
    *           if an exception occurs.
    */
-  protected RouteBuilder buildSparqlQueryProcessor() throws Exception {
+  @Override
+  protected RouteBuilder buildRoute() throws Exception {
     return new RouteBuilder() {
       @Override
       public void configure() throws Exception {
@@ -62,29 +42,6 @@ public class SparqlQueryComponent {
             .to(outputStream);
       }
     };
-  }
-
-  /**
-   * Stops the SPARQL query route.
-   */
-  public void stop() {
-    if (rb != null) {
-      try {
-        cc.removeRoute(rb.toString());
-      } catch (Exception e) {
-        log.error("Could not remove route " + rb + " " + e);
-      }
-    }
-  }
-
-  /**
-   * Sets the CamelContext for the route.
-   *
-   * @param cc
-   *          the CamelContext for the route.
-   */
-  public void setCamelContext(CamelContext cc) {
-    this.cc = cc;
   }
 
   /**
@@ -128,5 +85,22 @@ public class SparqlQueryComponent {
    */
   public void setResultsFormat(String resultsFormatName) {
     this.resultsFormatName = resultsFormatName;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append(this.getClass().getName() + " [inputStream=");
+    builder.append(inputStream);
+    builder.append(", outputStream=");
+    builder.append(outputStream);
+    builder.append(", query=");
+    builder.append(query);
+    builder.append(", resultsFormatName=");
+    builder.append(resultsFormatName);
+    builder.append(", routeId=");
+    builder.append(routeId);
+    builder.append("]");
+    return builder.toString();
   }
 }

--- a/umd-fcrepo-sparql-query/src/main/java/edu/umd/lib/fcrepo/camel/sparql/query/SparqlQueryFactory.java
+++ b/umd-fcrepo-sparql-query/src/main/java/edu/umd/lib/fcrepo/camel/sparql/query/SparqlQueryFactory.java
@@ -1,65 +1,46 @@
 
 package edu.umd.lib.fcrepo.camel.sparql.query;
 
-import java.util.Collections;
 import java.util.Dictionary;
-import java.util.HashMap;
-import java.util.Hashtable;
-import java.util.Map;
 
 import org.apache.camel.CamelContext;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
-import org.osgi.framework.ServiceRegistration;
-import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.cm.ConfigurationException;
-import org.osgi.service.cm.ManagedServiceFactory;
-import org.osgi.util.tracker.ServiceTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import edu.umd.lib.osgi.service.AbstractManagedServiceFactory;
+
 /**
- * ManagedServiceFactory implementation for creating SparqlQueryComponent instances.
+ * AbstractManagedServiceFactory implementation for creating SparqlQueryComponent instances.
  */
-public class SparqlQueryFactory implements ManagedServiceFactory {
+public class SparqlQueryFactory extends AbstractManagedServiceFactory<SparqlQueryComponent> {
+  private Logger log = LoggerFactory.getLogger(SparqlQueryFactory.class);
+
   public final static String INPUT_STREAM = "input.stream";
   public final static String OUTPUT_STREAM = "output.stream";
   public final static String QUERY = "query";
   public final static String RESULTS_FORMAT = "results.format";
 
-  private BundleContext bundleContext;
-  private CamelContext camelContext;
-  private ServiceRegistration registration;
-  private ServiceTracker tracker;
-  private Logger log = LoggerFactory.getLogger(SparqlQueryFactory.class);
-  private String configurationPid;
-  private Map<String, SparqlQueryComponent> dispatchEngines = Collections
-      .synchronizedMap(new HashMap<String, SparqlQueryComponent>());
-
   /**
-   * Override ManagedServiceFactory interfaces.
+   * Creates and returns a new SparqlQueryComponent from the given parameters.
+   *
+   * @param inputStream
+   *          the input stream for the component
+   * @param outputStream
+   *          the output stream for the component
+   * @param camelContext
+   *          the CamelContext for the component
+   * @param dict
+   *          the Dictionary containing the blueprint properties.
+   * @return a new SparqlQueryComponent from the given parameters.
    */
   @Override
-  public String getName() {
-    return configurationPid;
-  }
-
-  @Override
-  public void updated(String pid, Dictionary<String, ?> dict) throws ConfigurationException {
-    log.info("updated " + pid + " with " + dict.toString());
-    SparqlQueryComponent engine = null;
-
-    if (dispatchEngines.containsKey(pid)) {
-      engine = dispatchEngines.get(pid);
-
-      if (engine != null) {
-        destroyEngine(engine);
-      }
-      dispatchEngines.remove(pid);
-    }
+  protected SparqlQueryComponent createServiceInstance(CamelContext camelContext, Dictionary<String, ?> dict)
+      throws ConfigurationException {
 
     String inputStream = getDictionaryEntry(dict, INPUT_STREAM);
     String outputStream = getDictionaryEntry(dict, OUTPUT_STREAM);
+
     String query = getDictionaryEntry(dict, QUERY);
     String resultsFormat = getDictionaryEntry(dict, RESULTS_FORMAT);
 
@@ -69,107 +50,13 @@ public class SparqlQueryFactory implements ManagedServiceFactory {
     log.debug("resultsFormat: " + resultsFormat);
 
     // Configuration was verified above, now create engine.
-    engine = new SparqlQueryComponent();
+    SparqlQueryComponent engine = new SparqlQueryComponent();
     engine.setCamelContext(camelContext);
     engine.setInputStream(inputStream);
     engine.setOutputStream(outputStream);
     engine.setQuery(query);
     engine.setResultsFormat(resultsFormat);
 
-    dispatchEngines.put(pid, engine);
-    log.debug("Start the engine...");
-    engine.start();
-  }
-
-  @Override
-  public void deleted(String pid) {
-    if (dispatchEngines.containsKey(pid)) {
-      SparqlQueryComponent engine = dispatchEngines.get(pid);
-
-      if (engine != null) {
-        destroyEngine(engine);
-      }
-      dispatchEngines.remove(pid);
-    }
-    log.info("deleted " + pid);
-  }
-
-  /**
-   * Retrieve the value at the given key from the given Dictionary, or throw a ConfigurationException
-   * if the key is not found or the value is the empty string.
-   *
-   * @param dict
-   *          the Dictionary to retrieve the value from
-   * @param key
-   *          the key to retrieve the value of
-   * @return the String value at the given key
-   * @throws ConfigurationException
-   *           if the key is not found, or the value is an empty string.
-   */
-  protected String getDictionaryEntry(Dictionary<String, ?> dict, String key)
-      throws ConfigurationException {
-    String value = (String) dict.get(key);
-    if ((value != null) && (!value.trim().isEmpty())) {
-      log.debug(key + " set to " + value);
-      return value;
-    } else {
-      throw new ConfigurationException(key, "Key is missing or empty");
-    }
-  }
-
-  private void destroyEngine(SparqlQueryComponent engine) {
-    engine.stop();
-  }
-
-  /**
-   * Initialization method called via the blueprint
-   */
-  public void init() {
-    log.info("Starting " + this.getName());
-    Dictionary<String, String> servProps = new Hashtable<String, String>();
-    servProps.put(Constants.SERVICE_PID, configurationPid);
-    registration = bundleContext.registerService(ManagedServiceFactory.class.getName(), this, servProps);
-    tracker = new ServiceTracker(bundleContext, ConfigurationAdmin.class.getName(), null);
-    tracker.open();
-    log.info("Started " + this.getName());
-  }
-
-  /**
-   * Destroy method called via the blueprint
-   */
-  public void destroy() {
-    log.info("Destroying SparqlQueryFactory " + configurationPid);
-    registration.unregister();
-    tracker.close();
-  }
-
-  /**
-   * Sets the configuration pid from the blueprint
-   *
-   * @param configurationPid
-   *          the configuration pid from the blueprint
-   */
-  public void setConfigurationPid(String configurationPid) {
-    this.configurationPid = configurationPid;
-  }
-
-  /**
-   * Sets the bundle context from the blueprint
-   *
-   * @param bundleContext
-   *          the bundle context from the blueprint
-   */
-  public void setBundleContext(BundleContext bundleContext) {
-    this.bundleContext = bundleContext;
-  }
-
-  /**
-   * Sets the Camel context from the blueprint
-   *
-   * @param camelContext
-   *          the Camel context from the blueprint
-   */
-  public void setCamelContext(CamelContext camelContext) {
-    this.camelContext = camelContext;
+    return engine;
   }
 }

--- a/umd-fcrepo-triplestore/pom.xml
+++ b/umd-fcrepo-triplestore/pom.xml
@@ -61,10 +61,9 @@
         </dependency>
         
         <dependency>
-            <groupId>edu.umd.lib</groupId>
+            <groupId>edu.umd.lib.fcrepo</groupId>
             <artifactId>umd-osgi-extensions</artifactId>
             <version>${project.version}</version>
-            <type>jar</type>
         </dependency>
     </dependencies>
 

--- a/umd-fcrepo-triplestore/pom.xml
+++ b/umd-fcrepo-triplestore/pom.xml
@@ -59,6 +59,13 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core</artifactId>
         </dependency>
+        
+        <dependency>
+            <groupId>edu.umd.lib</groupId>
+            <artifactId>umd-osgi-extensions</artifactId>
+            <version>${project.version}</version>
+            <type>jar</type>
+        </dependency>
     </dependencies>
 
     <build>

--- a/umd-fcrepo-triplestore/src/main/java/edu/umd/lib/fcrepo/camel/triplestore/TriplestoreFactory.java
+++ b/umd-fcrepo-triplestore/src/main/java/edu/umd/lib/fcrepo/camel/triplestore/TriplestoreFactory.java
@@ -1,66 +1,30 @@
 
 package edu.umd.lib.fcrepo.camel.triplestore;
 
-import java.util.Collections;
 import java.util.Dictionary;
-import java.util.HashMap;
-import java.util.Hashtable;
-import java.util.Map;
 
 import org.apache.camel.CamelContext;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
-import org.osgi.framework.ServiceRegistration;
-import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.cm.ConfigurationException;
-import org.osgi.service.cm.ManagedServiceFactory;
-import org.osgi.util.tracker.ServiceTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import edu.umd.lib.osgi.service.AbstractManagedServiceFactory;
 
 /**
  * ManagedServiceFactory implementation for creating TriplestoreRouter
  * instances.
- *
- * This implementation is inspired by the code in Chapter 2, Recipe 6 of
- *
- * Nierbeck A., "Apache Karaf Cookbook : Over 60 Recipes to Help You Get the
- * Most Out of Apache Karaf Deployments.", Birmingham, UK: Packt Pub; 2014.
  */
-public class TriplestoreFactory implements ManagedServiceFactory {
+public class TriplestoreFactory extends AbstractManagedServiceFactory<TriplestoreRouter> {
+  private Logger log = LoggerFactory.getLogger(TriplestoreFactory.class);
+
   public final static String INPUT_STREAM = "input.stream";
   public final static String TRIPLESTORE_BASE_URL = "triplestore.baseUrl";
   public final static String ERROR_MAX_REDELIVERIES = "error.maxRedeliveries";
 
-  private BundleContext bundleContext;
-  private CamelContext camelContext;
-  private ServiceRegistration registration;
-  private ServiceTracker tracker;
-  private Logger log = LoggerFactory.getLogger(TriplestoreFactory.class);
-  private String configurationPid;
-  private Map<String, TriplestoreRouter> dispatchEngines = Collections.synchronizedMap(new HashMap<String, TriplestoreRouter>());
-
-  /**
-   * Override ManagedServiceFactory interfaces.
-   */
   @Override
-  public String getName() {
-    return configurationPid;
-  }
-
-  @Override
-  public void updated(String pid, Dictionary<String, ?> dict) throws ConfigurationException {
-    log.info("updated " + pid + " with " + dict.toString());
+  protected TriplestoreRouter createServiceInstance(CamelContext camelContext, Dictionary<String, ?> dict)
+      throws ConfigurationException {
     TriplestoreRouter engine = null;
-
-    if (dispatchEngines.containsKey(pid)) {
-      engine = dispatchEngines.get(pid);
-
-      if (engine != null) {
-        destroyEngine(engine);
-      }
-      dispatchEngines.remove(pid);
-    }
 
     String inputStream = getDictionaryEntry(dict, INPUT_STREAM);
     String triplestoreBaseUrl = getDictionaryEntry(dict, TRIPLESTORE_BASE_URL);
@@ -69,101 +33,13 @@ public class TriplestoreFactory implements ManagedServiceFactory {
     log.debug("inputStream: " + inputStream);
     log.debug("triplestoreBaseUrl: " + triplestoreBaseUrl);
     log.debug("errorMaxRedeliveries: " + maxRedeliveries);
-    //Configuration was verified above, now create engine.
+    // Configuration was verified above, now create engine.
+
     engine = new TriplestoreRouter();
     engine.setCamelContext(camelContext);
     engine.setInputStream(inputStream);
     engine.setTriplestoreBaseUrl(triplestoreBaseUrl);
     engine.setMaxRedeliveries(Integer.parseInt(maxRedeliveries));
-
-    dispatchEngines.put(pid, engine);
-    log.debug("Start the engine...");
-    engine.start();
-  }
-
-  @Override
-  public void deleted(String pid) {
-    if (dispatchEngines.containsKey(pid)) {
-      TriplestoreRouter engine = dispatchEngines.get(pid);
-
-      if (engine != null) {
-        destroyEngine(engine);
-      }
-      dispatchEngines.remove(pid);
-    }
-    log.info("deleted " + pid);
-  }
-
-  /**
-   * Retrieve the value at the given key from the given Dictionary, or throw a ConfigurationException
-   * if the key is not found or the value is the empty string.
-   *
-   * @param dict the Dictionary to retrieve the value from
-   * @param key the key to retrieve the value of
-   * @return the String value at the given key
-   * @throws ConfigurationException if the key is not found, or the value is an empty string.
-   */
-  protected String getDictionaryEntry(Dictionary<String, ?> dict, String key)
-      throws ConfigurationException {
-    String value = (String) dict.get(key);
-    if ((value != null) && (!value.trim().isEmpty())) {
-      log.debug(key + " set to " + value);
-      return value;
-    } else {
-      throw new ConfigurationException(key, "Key is missing or empty");
-    }
-  }
-
-  private void destroyEngine(TriplestoreRouter engine) {
-    engine.stop();
-  }
-
-  /**
-   * Initialization method called via the blueprint
-   */
-  public void init() {
-    log.info("Starting " + this.getName());
-    Dictionary<String, String> servProps = new Hashtable<String, String>();
-    servProps.put(Constants.SERVICE_PID, configurationPid);
-    registration = bundleContext.registerService(ManagedServiceFactory.class.getName(), this, servProps);
-    tracker = new ServiceTracker(bundleContext, ConfigurationAdmin.class.getName(), null);
-    tracker.open();
-    log.info("Started " + this.getName());
-  }
-
-  /**
-   * Destroy method called via the blueprint
-   */
-  public void destroy() {
-    log.info("Destroying triplestore factory " + configurationPid);
-    registration.unregister();
-    tracker.close();
-  }
-
-  /**
-   * Sets the configuration pid from the blueprint
-   *
-   * @param configurationPid the configuration pid from the blueprint
-   */
-  public void setConfigurationPid(String configurationPid) {
-    this.configurationPid = configurationPid;
-  }
-
-  /**
-   * Sets the bundle context from the blueprint
-   *
-   * @param bundleContext the bundle context from the blueprint
-   */
-  public void setBundleContext(BundleContext bundleContext) {
-    this.bundleContext = bundleContext;
-  }
-
-  /**
-   * Sets the Camel context from the blueprint
-   *
-   * @param camelContext the Camel context from the blueprint
-   */
-  public void setCamelContext(CamelContext camelContext) {
-    this.camelContext = camelContext;
+    return engine;
   }
 }

--- a/umd-fcrepo-triplestore/src/main/java/edu/umd/lib/fcrepo/camel/triplestore/TriplestoreRouter.java
+++ b/umd-fcrepo-triplestore/src/main/java/edu/umd/lib/fcrepo/camel/triplestore/TriplestoreRouter.java
@@ -1,6 +1,5 @@
 package edu.umd.lib.fcrepo.camel.triplestore;
 
-import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
@@ -8,42 +7,23 @@ import org.apache.camel.builder.RouteBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import edu.umd.lib.osgi.service.AbstractManagedServiceInstance;
+
 /**
  * A triplestore router, typically created by a TriplestoreFactory. It expects
  * N-Triples formatted RDF as the body of the input message, and sends that RDF,
  * wrapped in a SPARQL <code>INSERT DATA { ... }</code> statement, in a POST
  * request to the http: or https: URL set in <code>triplestore.baseUrl</code>.
  * The Content-Type of that request is "application/sparql-update".
- *
- * This implementation is inspired by the code in Chapter 2, Recipe 6 of
- *
- * Nierbeck A., "Apache Karaf Cookbook : Over 60 Recipes to Help You Get the
- * Most Out of Apache Karaf Deployments.", Birmingham, UK: Packt Pub; 2014.
  */
-public class TriplestoreRouter {
+public class TriplestoreRouter extends AbstractManagedServiceInstance {
+  private Logger log = LoggerFactory.getLogger(TriplestoreRouter.class);
 
   private String inputStream;
   private String triplestoreBaseUrl;
   private int maxRedeliveries;
-  private RouteBuilder rb;
-  private CamelContext cc;
 
-  private Logger log = LoggerFactory.getLogger(TriplestoreRouter.class);
-
-  public TriplestoreRouter() { }
-
-  /**
-   * Builds and starts the triplestore route.
-   */
-  public void start() {
-    try {
-      rb = buildTriplestoreRouter();
-      log.info("Route " + rb + " starting...");
-      cc.start();
-      cc.addRoutes(rb);
-    } catch (Exception ex) {
-      log.error("Could not process Triplestore " + ex);
-    }
+  public TriplestoreRouter() {
   }
 
   /**
@@ -52,7 +32,8 @@ public class TriplestoreRouter {
    * @return
    * @throws Exception
    */
-  protected RouteBuilder buildTriplestoreRouter() throws Exception {
+  @Override
+  protected RouteBuilder buildRoute() throws Exception {
     return new RouteBuilder() {
       @Override
       public void configure() throws Exception {
@@ -61,44 +42,23 @@ public class TriplestoreRouter {
          * A generic error handler (specific to this RouteBuilder)
          */
         onException(Exception.class)
-        .maximumRedeliveries(maxRedeliveries)
-        .log("Event Routing Error: ${routeId}");
+            .maximumRedeliveries(maxRedeliveries)
+            .log("Event Routing Error: ${routeId}");
 
         from(inputStream)
-        .routeId("Triplestore " + inputStream)
-        .description("Send RDF triples to a triplestore.")
-        .process(new SparqlInsertDataWrapper())
-        .to(triplestoreBaseUrl + "?useSystemProperties=true");
+            .routeId("Triplestore " + inputStream)
+            .description("Send RDF triples to a triplestore.")
+            .process(new SparqlInsertDataWrapper())
+            .to(triplestoreBaseUrl + "?useSystemProperties=true");
       }
     };
   }
 
   /**
-   * Stops the triplestore route.
-   */
-  public void stop() {
-    if (rb != null) {
-      try {
-        cc.removeRoute(rb.toString());
-      } catch (Exception e) {
-        log.error("Could not remove route " + rb + " " + e);
-      }
-    }
-  }
-
-  /**
-   * Sets the CamelContext for the route.
-   *
-   * @param cc the CamelContext for the route.
-   */
-  public void setCamelContext(CamelContext cc) {
-    this.cc = cc;
-  }
-
-  /**
    * Sets the input stream for the route.
    *
-   * @param inputStream the input stream for the route
+   * @param inputStream
+   *          the input stream for the route
    */
   public void setInputStream(String inputStream) {
     this.inputStream = inputStream;
@@ -107,7 +67,8 @@ public class TriplestoreRouter {
   /**
    * Sets the message recipients for the route.
    *
-   * @param triplestoreBaseUrl the message recipients for the route
+   * @param triplestoreBaseUrl
+   *          the message recipients for the route
    */
   public void setTriplestoreBaseUrl(String triplestoreBaseUrl) {
     this.triplestoreBaseUrl = triplestoreBaseUrl;
@@ -138,5 +99,20 @@ public class TriplestoreRouter {
       in.setBody("INSERT DATA { " + rdf + " }");
       log.debug((String) in.getBody());
     }
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append(this.getClass().getName() + " [inputStream=");
+    builder.append(inputStream);
+    builder.append(", triplestoreBaseUrl=");
+    builder.append(triplestoreBaseUrl);
+    builder.append(", maxRedeliveries=");
+    builder.append(maxRedeliveries);
+    builder.append(", routeId=");
+    builder.append(routeId);
+    builder.append("]");
+    return builder.toString();
   }
 }

--- a/umd-features/src/main/resources/features.xml
+++ b/umd-features/src/main/resources/features.xml
@@ -49,18 +49,21 @@
     <details>Installs the UMD broadcast service.</details>
 
     <bundle>mvn:edu.umd.lib.fcrepo/umd-fcrepo-broadcast/${project.version}</bundle>
+    <bundle>mvn:edu.umd.lib.fcrepo/umd-osgi-extensions/${project.version}</bundle>
   </feature>
 
   <feature name="umd-fcrepo-sparql-query" version="${project.version}">
     <details>Installs the UMD SPARQL query service.</details>
 
     <bundle>mvn:edu.umd.lib.fcrepo/umd-fcrepo-sparql-query/${project.version}</bundle>
+    <bundle>mvn:edu.umd.lib.fcrepo/umd-osgi-extensions/${project.version}</bundle>
   </feature>
 
   <feature name="umd-fcrepo-triplestore" version="${project.version}">
     <details>Installs the UMD triplestore service.</details>
 
     <bundle>mvn:edu.umd.lib.fcrepo/umd-fcrepo-triplestore/${project.version}</bundle>
+    <bundle>mvn:edu.umd.lib.fcrepo/umd-osgi-extensions/${project.version}</bundle>
   </feature>
   
   <feature name="umd-fcrepo-notification" version="${project.version}">

--- a/umd-osgi-extensions/README.md
+++ b/umd-osgi-extensions/README.md
@@ -13,4 +13,30 @@ of the project:
     <version>${project.version}</version>
     <type>jar</type>
 </dependency>
-``` 
+```
+
+If using with a Karaf feature, include this bundle as a dependency in
+the "features.xml" file (such as umd-features/src/main/resources/features.xml):
+
+```
+  <feature name="..." version="${project.version}">
+    ...
+    <bundle>mvn:edu.umd.lib.fcrepo/umd-osgi-extensions/${project.version}</bundle>
+  </feature>
+```
+
+## AbstractManagedServiceFactory/AbstractManagedServiceInstance
+
+These abstract classes can be subclassed to create OSGI services that
+allow multiple instances to be created by adding an appropriate
+configuration file to the Karaf etc/ directory.
+
+See the following projects for example usage:
+
+* umd-fcrepo-broadcast
+* umd-fcrepo-sparql-query
+* umd-fcrep-triplestore
+
+
+
+

--- a/umd-osgi-extensions/README.md
+++ b/umd-osgi-extensions/README.md
@@ -1,0 +1,16 @@
+# umd-osgi-extensions
+
+This project provides useful classes to other projects in this
+repository.
+
+To include these classes, add the following to the "pom.xml" file
+of the project:
+
+```
+<dependency>
+    <groupId>edu.umd.lib</groupId>
+    <artifactId>umd-osgi-extensions</artifactId>
+    <version>${project.version}</version>
+    <type>jar</type>
+</dependency>
+``` 

--- a/umd-osgi-extensions/pom.xml
+++ b/umd-osgi-extensions/pom.xml
@@ -2,34 +2,53 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>edu.umd.lib</groupId>
-  <artifactId>umd-osgi-extensions</artifactId>
-  <name>UMD OSGI Extensions</name>
-  <description>UMD Libraries Extensions for OSGI</description>
+    <modelVersion>4.0.0</modelVersion>
   
-  <parent>
-    <groupId>edu.umd.lib.fcrepo</groupId>
-    <artifactId>umd-fcrepo-camel-extensions</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
-  </parent>
+    <parent>
+        <groupId>edu.umd.lib.fcrepo</groupId>
+        <artifactId>umd-fcrepo-camel-extensions</artifactId>
+       <version>1.4.0-SNAPSHOT</version>
+    </parent>
   
-  <dependencies>
-    <!-- OSGI -->
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
-    </dependency>
+    <artifactId>umd-osgi-extensions</artifactId>
+    <packaging>bundle</packaging>
+    <name>UMD OSGI Extensions</name>
+    <description>UMD Libraries Extensions for OSGI</description>
+  
+    <properties>
+        <osgi.import.packages>
+            *
+        </osgi.import.packages>
+        <osgi.export.packages>
+            edu.umd.lib.osgi.service*;version=${project.version}
+        </osgi.export.packages>
+    </properties>
+  
+    <dependencies>
+        <!-- OSGI -->
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+        </dependency>
     
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.compendium</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.compendium</artifactId>
+        </dependency>
   
-    <!-- Apache Camel -->
-    <dependency>
-      <groupId>org.apache.camel</groupId>
-      <artifactId>camel-core</artifactId>
-    </dependency>
-  </dependencies>
+        <!-- Apache Camel -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-core</artifactId>
+        </dependency>
+    </dependencies>
+  
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/umd-osgi-extensions/pom.xml
+++ b/umd-osgi-extensions/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>edu.umd.lib</groupId>
+  <artifactId>umd-osgi-extensions</artifactId>
+  <name>UMD OSGI Extensions</name>
+  <description>UMD Libraries Extensions for OSGI</description>
+  
+  <parent>
+    <groupId>edu.umd.lib.fcrepo</groupId>
+    <artifactId>umd-fcrepo-camel-extensions</artifactId>
+    <version>1.4.0-SNAPSHOT</version>
+  </parent>
+  
+  <dependencies>
+    <!-- OSGI -->
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.core</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.compendium</artifactId>
+    </dependency>
+  
+    <!-- Apache Camel -->
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-core</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/umd-osgi-extensions/src/main/java/edu/umd/lib/osgi/service/AbstractManagedServiceFactory.java
+++ b/umd-osgi-extensions/src/main/java/edu/umd/lib/osgi/service/AbstractManagedServiceFactory.java
@@ -1,0 +1,177 @@
+
+package edu.umd.lib.osgi.service;
+
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
+
+import org.apache.camel.CamelContext;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.cm.ConfigurationException;
+import org.osgi.service.cm.ManagedServiceFactory;
+import org.osgi.util.tracker.ServiceTracker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Abstract implementation of ManagedServiceFactory that provides commonly used code for constructing
+ * service instances.
+ * <p>
+ * This implementation is inspired by the code in Chapter 2, Recipe 6 of
+ * <p>
+ * Nierbeck A., "Apache Karaf Cookbook : Over 60 Recipes to Help You Get the Most Out of Apache Karaf Deployments.",
+ * Birmingham, UK: Packt Pub; 2014.
+ *
+ * @param <T>
+ *          the type of the ManagedServiceInstance implementation that will be created
+ */
+public abstract class AbstractManagedServiceFactory<T extends AbstractManagedServiceInstance>
+    implements ManagedServiceFactory {
+  private Logger log = LoggerFactory.getLogger(AbstractManagedServiceFactory.class);
+
+  protected BundleContext bundleContext;
+  protected CamelContext camelContext;
+  protected ServiceRegistration registration;
+  protected ServiceTracker tracker;
+  protected String configurationPid;
+  protected Map<String, T> dispatchEngines = Collections.synchronizedMap(new HashMap<String, T>());
+
+  /**
+   * Override ManagedServiceFactory interfaces.
+   */
+  @Override
+  public String getName() {
+    return configurationPid;
+  }
+
+  @Override
+  public void updated(String pid, Dictionary<String, ?> dict) throws ConfigurationException {
+    log.info("updated " + pid + " with " + dict.toString());
+    T engine = null;
+
+    if (dispatchEngines.containsKey(pid)) {
+      engine = dispatchEngines.get(pid);
+
+      if (engine != null) {
+        destroyEngine(engine);
+      }
+      dispatchEngines.remove(pid);
+    }
+
+    // Configuration was verified above, now create engine.
+    engine = createServiceInstance(camelContext, dict);
+
+    dispatchEngines.put(pid, engine);
+    log.debug("Start the engine...");
+    engine.start();
+  }
+
+  /**
+   * Creates and returns a new instance of the service from the given parameters.
+   *
+   * @param camelContext
+   *          the CamelContext for the component
+   * @param dict
+   *          the Dictionary containing the blueprint properties.
+   * @return a new instance of the service, configured using the given parameters.
+   */
+  protected abstract T createServiceInstance(CamelContext camelContext, Dictionary<String, ?> dict)
+      throws ConfigurationException;
+
+  @Override
+  public void deleted(String pid) {
+    if (dispatchEngines.containsKey(pid)) {
+      T engine = dispatchEngines.get(pid);
+
+      if (engine != null) {
+        destroyEngine(engine);
+      }
+      dispatchEngines.remove(pid);
+    }
+    log.info("deleted " + pid);
+  }
+
+  /**
+   * Retrieve the value at the given key from the given Dictionary, or throw a ConfigurationException
+   * if the key is not found or the value is the empty string.
+   *
+   * @param dict
+   *          the Dictionary to retrieve the value from
+   * @param key
+   *          the key to retrieve the value of
+   * @return the String value at the given key
+   * @throws ConfigurationException
+   *           if the key is not found, or the value is an empty string.
+   */
+  protected String getDictionaryEntry(Dictionary<String, ?> dict, String key)
+      throws ConfigurationException {
+    String value = (String) dict.get(key);
+    if ((value != null) && (!value.trim().isEmpty())) {
+      log.debug(key + " set to " + value);
+      return value;
+    } else {
+      throw new ConfigurationException(key, "Key is missing or empty");
+    }
+  }
+
+  private void destroyEngine(T engine) {
+    engine.stop();
+  }
+
+  /**
+   * Initialization method called via the blueprint
+   */
+  public void init() {
+    log.info("Starting " + this.getName());
+    Dictionary<String, String> servProps = new Hashtable<String, String>();
+    servProps.put(Constants.SERVICE_PID, configurationPid);
+    registration = bundleContext.registerService(ManagedServiceFactory.class.getName(), this, servProps);
+    tracker = new ServiceTracker(bundleContext, ConfigurationAdmin.class.getName(), null);
+    tracker.open();
+    log.info("Started " + this.getName());
+  }
+
+  /**
+   * Destroy method called via the blueprint
+   */
+  public void destroy() {
+    log.info("Destroying SparqlQueryFactory " + configurationPid);
+    registration.unregister();
+    tracker.close();
+  }
+
+  /**
+   * Sets the configuration pid from the blueprint
+   *
+   * @param configurationPid
+   *          the configuration pid from the blueprint
+   */
+  public void setConfigurationPid(String configurationPid) {
+    this.configurationPid = configurationPid;
+  }
+
+  /**
+   * Sets the bundle context from the blueprint
+   *
+   * @param bundleContext
+   *          the bundle context from the blueprint
+   */
+  public void setBundleContext(BundleContext bundleContext) {
+    this.bundleContext = bundleContext;
+  }
+
+  /**
+   * Sets the Camel context from the blueprint
+   *
+   * @param camelContext
+   *          the Camel context from the blueprint
+   */
+  public void setCamelContext(CamelContext camelContext) {
+    this.camelContext = camelContext;
+  }
+}

--- a/umd-osgi-extensions/src/main/java/edu/umd/lib/osgi/service/AbstractManagedServiceFactory.java
+++ b/umd-osgi-extensions/src/main/java/edu/umd/lib/osgi/service/AbstractManagedServiceFactory.java
@@ -36,8 +36,8 @@ public abstract class AbstractManagedServiceFactory<T extends AbstractManagedSer
 
   protected BundleContext bundleContext;
   protected CamelContext camelContext;
-  protected ServiceRegistration registration;
-  protected ServiceTracker tracker;
+  protected ServiceRegistration<?> registration;
+  protected ServiceTracker<T, T> tracker;
   protected String configurationPid;
   protected Map<String, T> dispatchEngines = Collections.synchronizedMap(new HashMap<String, T>());
 
@@ -131,7 +131,7 @@ public abstract class AbstractManagedServiceFactory<T extends AbstractManagedSer
     Dictionary<String, String> servProps = new Hashtable<String, String>();
     servProps.put(Constants.SERVICE_PID, configurationPid);
     registration = bundleContext.registerService(ManagedServiceFactory.class.getName(), this, servProps);
-    tracker = new ServiceTracker(bundleContext, ConfigurationAdmin.class.getName(), null);
+    tracker = new ServiceTracker<T, T>(bundleContext, ConfigurationAdmin.class.getName(), null);
     tracker.open();
     log.info("Started " + this.getName());
   }
@@ -140,7 +140,7 @@ public abstract class AbstractManagedServiceFactory<T extends AbstractManagedSer
    * Destroy method called via the blueprint
    */
   public void destroy() {
-    log.info("Destroying SparqlQueryFactory " + configurationPid);
+    log.info("Destroying " + this.getName());
     registration.unregister();
     tracker.close();
   }
@@ -173,5 +173,14 @@ public abstract class AbstractManagedServiceFactory<T extends AbstractManagedSer
    */
   public void setCamelContext(CamelContext camelContext) {
     this.camelContext = camelContext;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append(this.getClass().getName() + " [configurationPid=");
+    builder.append(configurationPid);
+    builder.append("]");
+    return builder.toString();
   }
 }

--- a/umd-osgi-extensions/src/main/java/edu/umd/lib/osgi/service/AbstractManagedServiceInstance.java
+++ b/umd-osgi-extensions/src/main/java/edu/umd/lib/osgi/service/AbstractManagedServiceInstance.java
@@ -1,0 +1,86 @@
+package edu.umd.lib.osgi.service;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Abstract class for services that may have multiple instances.
+ * <p>
+ * This implementation is inspired by the code in Chapter 2, Recipe 6 of
+ * <p>
+ * Nierbeck A., "Apache Karaf Cookbook : Over 60 Recipes to Help You Get the Most Out of Apache Karaf Deployments.",
+ * Birmingham, UK: Packt Pub; 2014.
+ */
+public abstract class AbstractManagedServiceInstance {
+  /**
+   * The id of the route for this instance
+   */
+  protected String routeId;
+
+  /**
+   * The CamelContext associated with this instance.
+   */
+  protected CamelContext cc;
+
+  private Logger log = LoggerFactory.getLogger(AbstractManagedServiceInstance.class);
+
+  /**
+   * Default constructor
+   */
+  public AbstractManagedServiceInstance() {
+  }
+
+  /**
+   * Builds and starts the route.
+   */
+  public void start() {
+    try {
+      RouteBuilder rb = buildRoute();
+      routeId = rb.toString();
+      log.info("Route " + routeId + " starting...");
+      cc.start();
+      cc.addRoutes(rb);
+    } catch (Exception ex) {
+      log.error("Could not create route " + ex);
+    }
+  }
+
+  /**
+   * Returns a RouteBuilder, using the values from the instance variables in the configuration file.
+   *
+   * @return a RouteBuilder incorporating the service instance
+   * @throws Exception
+   *           if an exception occurs.
+   */
+  protected abstract RouteBuilder buildRoute() throws Exception;
+
+  /**
+   * Stops the route.
+   */
+  public void stop() {
+    if (routeId != null) {
+      try {
+        cc.removeRoute(routeId);
+      } catch (Exception e) {
+        log.error("Could not remove route " + routeId + " " + e);
+      }
+    }
+  }
+
+  /**
+   * Sets the CamelContext for the route.
+   *
+   * @param cc
+   *          the CamelContext for the route.
+   */
+  public void setCamelContext(CamelContext cc) {
+    this.cc = cc;
+  }
+
+  @Override
+  public String toString() {
+    return this.getClass().getName() + " [routeId=" + routeId + "]";
+  }
+}


### PR DESCRIPTION
Created "umd-osgi-extensions" bundle with abstract classes for
simplifying the creation of services that may have multiple instances.

Updated the umd-fcrepo-broadcast, umd-fcrepo-sparql-query,
and umd-fcrepo-triplestore repositories to use the abstract classes.

https://issues.umd.edu/browse/LIBFCREPO-478