### PR TITLE
LIBFCREPO-496. Modified NotificationRouter for multiple instances

### DIFF
--- a/umd-fcrepo-broadcast/pom.xml
+++ b/umd-fcrepo-broadcast/pom.xml
@@ -64,7 +64,6 @@
             <groupId>edu.umd.lib.fcrepo</groupId>
             <artifactId>umd-osgi-extensions</artifactId>
             <version>${project.version}</version>
-            <type>jar</type>
         </dependency>
     </dependencies>
 

--- a/umd-fcrepo-broadcast/src/main/java/edu/umd/lib/fcrepo/camel/broadcast/BroadcastDispatcher.java
+++ b/umd-fcrepo-broadcast/src/main/java/edu/umd/lib/fcrepo/camel/broadcast/BroadcastDispatcher.java
@@ -1,8 +1,6 @@
 package edu.umd.lib.fcrepo.camel.broadcast;
 
 import org.apache.camel.builder.RouteBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import edu.umd.lib.osgi.service.AbstractManagedServiceInstance;
 
@@ -10,8 +8,6 @@ import edu.umd.lib.osgi.service.AbstractManagedServiceInstance;
  * A broadcast service instance, typically created and controlled via the BroadcastFactory.
  */
 public class BroadcastDispatcher extends AbstractManagedServiceInstance {
-  private Logger log = LoggerFactory.getLogger(BroadcastDispatcher.class);
-
   private String inputStream;
   private String messageRecipients;
 
@@ -62,9 +58,7 @@ public class BroadcastDispatcher extends AbstractManagedServiceInstance {
   @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();
-    builder.append(this.getClass().getName() + " [log=");
-    builder.append(log);
-    builder.append(", inputStream=");
+    builder.append(this.getClass().getName() + " [inputStream=");
     builder.append(inputStream);
     builder.append(", messageRecipients=");
     builder.append(messageRecipients);

--- a/umd-fcrepo-notification/pom.xml
+++ b/umd-fcrepo-notification/pom.xml
@@ -60,16 +60,22 @@
             <artifactId>camel-core</artifactId>
         </dependency>
         
-    	<dependency>
-      		<groupId>org.apache.camel</groupId>
-      		<artifactId>camel-blueprint</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-blueprint</artifactId>
+        </dependency>
         
         <dependency>
             <groupId>javax.mail</groupId>
             <artifactId>javax.mail-api</artifactId>
             <version>1.6.1</version>
         </dependency>
+        
+        <dependency>
+            <groupId>edu.umd.lib.fcrepo</groupId>
+            <artifactId>umd-osgi-extensions</artifactId>
+            <version>${project.version}</version>
+        </dependency>        
 
 
         <!-- testing -->

--- a/umd-fcrepo-notification/src/main/java/edu/umd/lib/fcrepo/camel/notification/NotificationFactory.java
+++ b/umd-fcrepo-notification/src/main/java/edu/umd/lib/fcrepo/camel/notification/NotificationFactory.java
@@ -1,0 +1,42 @@
+
+package edu.umd.lib.fcrepo.camel.notification;
+
+import java.util.Dictionary;
+
+import org.apache.camel.CamelContext;
+import org.osgi.service.cm.ConfigurationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import edu.umd.lib.osgi.service.AbstractManagedServiceFactory;
+
+/**
+ * ManagedServiceFactory implementation for creating NotificationRouter instances.
+ */
+public class NotificationFactory extends AbstractManagedServiceFactory<NotificationRouter> {
+  private Logger log = LoggerFactory.getLogger(NotificationFactory.class);
+
+  public final static String INPUT_STREAM = "input.stream";
+  public final static String NOTIFICATION_RECIPIENTS = "notification.recipients";
+  public final static String ERROR_MAX_REDELIVERIES = "error.maxRedeliveries";
+
+  @Override
+  protected NotificationRouter createServiceInstance(CamelContext camelContext,
+      Dictionary<String, ?> dict) throws ConfigurationException {
+    String notificationRecipients = getDictionaryEntry(dict, NOTIFICATION_RECIPIENTS);
+    String inputStream = getDictionaryEntry(dict, INPUT_STREAM);
+    String maxRedeliveries = getDictionaryEntry(dict, ERROR_MAX_REDELIVERIES);
+
+    log.debug("inputStream: " + inputStream);
+    log.debug("notificationRecipients: " + notificationRecipients);
+    log.debug("errorMaxRedeliveries: " + maxRedeliveries);
+
+    // Configuration was verified above, now create engine.
+    NotificationRouter engine = new NotificationRouter();
+    engine.setCamelContext(camelContext);
+    engine.setInputStream(inputStream);
+    engine.setNotificationRecipients(notificationRecipients);
+    engine.setMaxRedeliveries(maxRedeliveries);
+    return engine;
+  }
+}

--- a/umd-fcrepo-notification/src/main/java/edu/umd/lib/fcrepo/camel/notification/NotificationRouter.java
+++ b/umd-fcrepo-notification/src/main/java/edu/umd/lib/fcrepo/camel/notification/NotificationRouter.java
@@ -1,45 +1,98 @@
 package edu.umd.lib.fcrepo.camel.notification;
 
-
-import static org.slf4j.LoggerFactory.getLogger;
-
 import org.apache.camel.Exchange;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
-import org.slf4j.Logger;
 
-public class NotificationRouter extends RouteBuilder  {
+import edu.umd.lib.osgi.service.AbstractManagedServiceInstance;
 
-  private static final Logger LOGGER = getLogger(NotificationRouter.class);
+public class NotificationRouter extends AbstractManagedServiceInstance {
 
+  private String inputStream;
+  private String notificationRecipients;
+  private String maxRedeliveries;
+
+  /**
+   * Returns a RouteBuilder, using the values from the instance variables
+   *
+   * @return
+   * @throws Exception
+   */
   @Override
-  public void configure() throws Exception {
+  protected RouteBuilder buildRoute() throws Exception {
+    return new RouteBuilder() {
+      @Override
+      public void configure() throws Exception {
+        /**
+         * A generic error handler (specific to this RouteBuilder)
+         */
+        onException(Exception.class)
+            .maximumRedeliveries(maxRedeliveries)
+            .log("Notification Routing Error: ${routeId}");
 
-    /**
-     * A generic error handler (specific to this RouteBuilder)
-     */
-    onException(Exception.class)
-    .maximumRedeliveries("{{error.maxRedeliveries}}")
-    .log("Notification Routing Error: ${routeId}");
-
-    /**
-     * Handle fixity events
-     */
-    from("{{input.stream}}")
-    .routeId("Notification {{input.stream}}")
-    .log(LoggingLevel.INFO, LOGGER, "Sending to {{notification.recipients}}")
-    .process(new Processor() { 
-    	public void process(Exchange exchange) throws Exception {
-    		Message in = exchange.getIn();
-    		String body = in.getBody(String.class);
-    		String uri = (String) in.getHeader("CamelFcrepoUri");
-    		exchange.getOut().setBody("Notification for the following URI: " + uri + "\n\n\n" + body );
-    	}
-    })
-    .to("{{notification.recipients}}");
+        from(inputStream)
+            .routeId("NotificationRouter " + inputStream)
+            .log(LoggingLevel.INFO, log, "Sending to " + notificationRecipients)
+            .to(notificationRecipients)
+            .process(new Processor() {
+              @Override
+              public void process(Exchange exchange) throws Exception {
+                Message in = exchange.getIn();
+                String body = in.getBody(String.class);
+                String uri = (String) in.getHeader("CamelFcrepoUri");
+                exchange.getOut().setBody("Notification for the following URI: " + uri + "\n\n\n" + body);
+              }
+            });
+            
+      }
+    };
   }
 
- 
+  /**
+   * Sets the input stream for the route.
+   *
+   * @param inputStream
+   *          the input stream for the route
+   */
+  public void setInputStream(String inputStream) {
+    this.inputStream = inputStream;
+  }
+
+  /**
+   * Sets the notification recipients for the route.
+   *
+   * @param notificationRecipients
+   *          the notification recipients for the route
+   */
+  public void setNotificationRecipients(String notificationRecipients) {
+    this.notificationRecipients = notificationRecipients;
+  }
+
+  /**
+   * Sets the maximum number of times to attempt delivery.
+   *
+   * @param maxRedeliveries
+   *          the maximum number of times to attempt delivery..
+   */
+  public void setMaxRedeliveries(String maxRedeliveries) {
+    this.maxRedeliveries = maxRedeliveries;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append(this.getClass().getName() + " [log=");
+    builder.append(", inputStream=");
+    builder.append(inputStream);
+    builder.append(", notificationRecipients=");
+    builder.append(notificationRecipients);
+    builder.append(", maxRedeliveries=");
+    builder.append(maxRedeliveries);
+    builder.append(", routeId=");
+    builder.append(routeId);
+    builder.append("]");
+    return builder.toString();
+  }
 }

--- a/umd-fcrepo-notification/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/umd-fcrepo-notification/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -7,18 +7,18 @@
        http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
        http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
 
-   <!-- OSGI blueprint property placeholder -->
-   <cm:property-placeholder id="properties" persistent-id="edu.umd.lib.fcrepo.camel.notification" update-strategy="reload">
-     <cm:default-properties>
-       <cm:property name="error.maxRedeliveries" value="10"/>
-       <cm:property name="notification.recipients" value=""/>
-       <cm:property name="input.stream" value="activemq:queue:fixityfailure"/>
-     
-     </cm:default-properties>
-   </cm:property-placeholder>
-
-  <camelContext id="FcrepoNotification" xmlns="http://camel.apache.org/schema/blueprint">
-    <package>edu.umd.lib.fcrepo.camel.notification</package>
+  <cm:property-placeholder persistent-id="edu.umd.lib.fcrepo.camel.notification" update-strategy="reload">
+      <cm:default-properties>
+        <cm:property name="edu.umd.lib.fcrepo.camel.notification.pid" value="edu.umd.lib.fcrepo.camel.notification"/>
+      </cm:default-properties>
+  </cm:property-placeholder>
+  
+  <camelContext id="FcrepoNotification" xmlns="http://camel.apache.org/schema/blueprint" autoStartup="true">
   </camelContext>
-
+  
+  <bean id="notification" class="edu.umd.lib.fcrepo.camel.notification.NotificationFactory" init-method="init" destroy-method="destroy">
+    <property name="bundleContext" ref="blueprintBundleContext"/>
+    <property name="configurationPid" value="${edu.umd.lib.fcrepo.camel.notification.pid}"/>
+    <property name="camelContext" ref="FcrepoNotification"/>
+  </bean>
 </blueprint>

--- a/umd-osgi-extensions/README.md
+++ b/umd-osgi-extensions/README.md
@@ -36,7 +36,18 @@ See the following projects for example usage:
 * umd-fcrepo-broadcast
 * umd-fcrepo-sparql-query
 * umd-fcrep-triplestore
+* umd-fcrepo-notification
 
+### Instance Route Ids
+
+When creating multiple instances, it is _critical_ that the "route id"
+of the instance be unique. If two instances have the same route id, one
+of the instances will overwrite the other (exactly which one "wins"
+is arbitrary).
+
+In the above services, it is assumed that the the input stream for an
+instance will always be unique, so the route id is created from a
+combination of the service name, and the input stream. 
 
 
 


### PR DESCRIPTION
Changed NotificationRouter to extend AbstractManagedServiceInstance and
added NotificationFactory to allow multiple instances to be created.

Also made some minor unrelated fixes to BroadcastDispatacher and umd-fcrepo-broadcast/pom.xml

https://issues.umd.edu/browse/LIBFCREPO-496