### PR TITLE
LIBFCREPO-682. Added umd-fcrepo-premis feature.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <marmotta.version>3.3.0</marmotta.version>
         <jena.version>3.5.0</jena.version>
         <fcrepo-camel.version>4.5.0</fcrepo-camel.version>
-        <fcrepo-camel-toolbox.version>4.7.2-umd-1.0</fcrepo-camel-toolbox.version>
+        <fcrepo-camel-toolbox.version>4.8.0</fcrepo-camel-toolbox.version>
         <fcrepo-java-client.version>0.2.1</fcrepo-java-client.version>
         <logback.version>1.1.7</logback.version>
         <slf4j.version>1.7.20</slf4j.version>
@@ -59,6 +59,7 @@
         <module>umd-fcrepo-triplestore</module>
         <module>umd-fcrepo-notification</module>
         <module>umd-osgi-extensions</module>
+      <module>umd-fcrepo-premis</module>
     </modules>
 
     <dependencyManagement>

--- a/umd-fcrepo-event-router/src/main/java/edu/umd/lib/fcrepo/camel/routing/Router.java
+++ b/umd-fcrepo-event-router/src/main/java/edu/umd/lib/fcrepo/camel/routing/Router.java
@@ -32,6 +32,8 @@ public class Router extends RouteBuilder {
 
   private static final String JMS_USER = "org.fcrepo.jms.user";
 
+  private static final String JMS_USER_AGENT = "org.fcrepo.jms.userAgent";
+
   private static final String JMS_EVENT_TYPE = "org.fcrepo.jms.eventType";
 
   private static final String JMS_RESOURCE_TYPE = "org.fcrepo.jms.resourceType";
@@ -56,15 +58,20 @@ public class Router extends RouteBuilder {
     .log("Routing Error: ${routeId}");
 
 
-    /**
+    /*
      * extract Fedora-specific message information from the body and turn it into headers, then
      * send for further message routing
      */
     from("broker:{{input.queue.name}}")
         .routeId("UmdFcrepoEventRouter")
         .process(new EventProcessor())
+        .setHeader("CamelFcrepoUser", simple(headerString(JMS_USER)))
+        .setHeader("CamelFcrepoUserAgent", simple(headerString(JMS_USER_AGENT)))
+        .setHeader("CamelFcrepoEventType", simple(headerString(JMS_EVENT_TYPE)))
+        .setHeader("CamelFcrepoResourceType", simple(headerString(JMS_RESOURCE_TYPE)))
+        .log(LoggingLevel.DEBUG, logger, "Event user: " + headerString("CamelFcrepoUser"))
+        .log(LoggingLevel.DEBUG, logger, "Event user agent: " + headerString("CamelFcrepoUserAgent"))
         .log(LoggingLevel.INFO, logger, "Routing event with id: " + headerString(JMS_IDENTIFIER))
-        .log(LoggingLevel.DEBUG, logger, "Event user: " + headerString(JMS_USER))
         .recipientList(simple("direct:all,direct:binary"))
         .ignoreInvalidEndpoints();
     

--- a/umd-fcrepo-premis/pom.xml
+++ b/umd-fcrepo-premis/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>edu.umd.lib.fcrepo</groupId>
+    <artifactId>umd-fcrepo-camel-extensions</artifactId>
+    <version>1.6.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>umd-fcrepo-premis</artifactId>
+  <packaging>bundle</packaging>
+
+  <name>UMD Fcrepo PREMIS</name>
+  <description>UMD Fcrepo PREMIS Project.</description>
+
+  <properties>
+    <osgi.import.packages>
+      *
+    </osgi.import.packages>
+    <osgi.export.packages>
+      edu.umd.lib.fcrepo.camel.premis*;version=${project.version}
+    </osgi.export.packages>
+  </properties>
+
+  <dependencies>
+    <!-- OSGI -->
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.compendium</artifactId>
+    </dependency>
+
+    <!-- Apache Camel -->
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>edu.umd.lib.fcrepo</groupId>
+      <artifactId>umd-osgi-extensions</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>jena-core</artifactId>
+      <version>3.1.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.fcrepo.camel</groupId>
+      <artifactId>fcrepo-camel</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/umd-fcrepo-premis/src/main/java/edu/umd/lib/fcrepo/camel/premis/AuditPremisProcessor.java
+++ b/umd-fcrepo-premis/src/main/java/edu/umd/lib/fcrepo/camel/premis/AuditPremisProcessor.java
@@ -1,0 +1,172 @@
+package edu.umd.lib.fcrepo.camel.premis;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Collections.emptyList;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static org.apache.jena.datatypes.xsd.XSDDatatype.XSDdateTime;
+import static org.apache.jena.datatypes.xsd.XSDDatatype.XSDstring;
+import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
+import static org.apache.jena.rdf.model.ResourceFactory.*;
+import static org.apache.jena.riot.RDFDataMgr.write;
+import static org.apache.jena.riot.RDFFormat.NTRIPLES;
+import static org.apache.jena.vocabulary.RDF.type;
+import static org.fcrepo.camel.FcrepoHeaders.*;
+
+/**
+ * A processor that converts an audit message into a sparql-update
+ * statement for an external triplestore.
+ *
+ * @author Aaron Coburn
+ * @author escowles
+ * @since 2015-04-09
+ */
+
+public class AuditPremisProcessor implements Processor {
+
+    private static final Logger log = LoggerFactory.getLogger(AuditPremisProcessor.class);
+
+    private static final String AUDIT = "http://fedora.info/definitions/v4/audit#";
+    private static final String PREMIS = "http://www.loc.gov/premis/rdf/v1#";
+    private static final String PROV = "http://www.w3.org/ns/prov#";
+    private static final String EVENT_TYPE = "http://id.loc.gov/vocabulary/preservation/eventType/";
+    private static final String EVENT_NAMESPACE = "http://fedora.info/definitions/v4/event#";
+    private static final String AS_NAMESPACE = "https://www.w3.org/ns/activitystreams#";
+    private static final String REPOSITORY = "http://fedora.info/definitions/v4/repository#";
+
+    private static final String CONTENT_MOD = AUDIT + "contentModification";
+    private static final String CONTENT_REM = AUDIT + "contentRemoval";
+    private static final String METADATA_MOD = AUDIT + "metadataModification";
+
+    private static final String CONTENT_ADD = EVENT_TYPE + "ing";
+    private static final String OBJECT_ADD = EVENT_TYPE + "cre";
+    private static final String OBJECT_REM = EVENT_TYPE + "del";
+
+    private static final String EVENT_BASE_URI = "CamelAuditEventBaseUri";
+    private static final String EVENT_URI = "CamelAuditEventUri";
+
+    /**
+     * Define how a message should be processed.
+     *
+     * @param exchange the current camel message exchange
+     */
+    public void process(final Exchange exchange) throws Exception {
+        final Message in = exchange.getIn();
+        final String eventURIBase = in.getHeader(EVENT_BASE_URI, String.class);
+        final String eventID = in.getHeader(FCREPO_EVENT_ID, String.class);
+        final Resource eventURI = createResource(eventURIBase + "/" + eventID);
+
+        // update exchange
+        in.setBody(serializedGraphForMessage(in, eventURI));
+        in.setHeader(EVENT_URI, eventURI.toString());
+        in.setHeader(Exchange.CONTENT_TYPE, "application/n-triples");
+    }
+
+    // namespaces and properties
+    private static final Resource INTERNAL_EVENT = createResource(AUDIT + "InternalEvent");
+    private static final Resource PREMIS_EVENT = createResource(PREMIS + "Event");
+    private static final Resource PROV_EVENT = createResource(PROV + "InstantaneousEvent");
+
+    private static final Property PREMIS_TIME = createProperty(PREMIS + "hasEventDateTime");
+    private static final Property PREMIS_OBJ = createProperty(PREMIS + "hasEventRelatedObject");
+    private static final Property PREMIS_AGENT = createProperty(PREMIS + "hasEventRelatedAgent");
+    private static final Property PREMIS_TYPE = createProperty(PREMIS + "hasEventType");
+
+    private static final String EMPTY_STRING = "";
+
+    private static List<String> parseStringToList(final String string) {
+        if (string == null) {
+            return emptyList();
+        } else {
+            return new ArrayList<>(Arrays.asList(string.split(",")));
+        }
+    }
+
+    /**
+     * Convert a Camel message to audit event description.
+     * @param message Camel message produced by an audit event
+     * @param subject RDF subject of the audit description
+     */
+    private static String serializedGraphForMessage(final Message message, final Resource subject) throws IOException {
+
+        // serialize triples
+        final ByteArrayOutputStream serializedGraph = new ByteArrayOutputStream();
+        final Model model = createDefaultModel();
+
+        // get info from jms message headers
+        final List<String> eventTypes = parseStringToList(message.getHeader(FCREPO_EVENT_TYPE, String.class));
+        final String dateTime = message.getHeader(FCREPO_DATE_TIME, EMPTY_STRING, String.class);
+        final String user = message.getHeader("CamelFcrepoUser", String.class);
+        final String userAgent = message.getHeader("CamelFcrepoUserAgent", String.class);
+        final List<String> resourceTypes = parseStringToList(message.getHeader(FCREPO_RESOURCE_TYPE, String.class));
+        final String identifier = message.getHeader(FCREPO_URI, EMPTY_STRING, String.class);
+        final Optional<String> premisType = getAuditEventType(eventTypes, resourceTypes);
+
+        model.add( model.createStatement(subject, type, INTERNAL_EVENT) );
+        model.add( model.createStatement(subject, type, PREMIS_EVENT) );
+        model.add( model.createStatement(subject, type, PROV_EVENT) );
+
+        // basic event info
+        model.add( model.createStatement(subject, PREMIS_TIME, createTypedLiteral(dateTime, XSDdateTime)) );
+        model.add( model.createStatement(subject, PREMIS_OBJ, createResource(identifier)) );
+
+        model.add( model.createStatement(subject, PREMIS_AGENT, createTypedLiteral(user, XSDstring)) );
+        model.add( model.createStatement(subject, PREMIS_AGENT, createTypedLiteral(userAgent, XSDstring)) );
+
+        premisType.ifPresent(rdfType -> {
+            model.add(model.createStatement(subject, PREMIS_TYPE, createResource(rdfType)));
+        });
+
+        write(serializedGraph, model, NTRIPLES);
+        return serializedGraph.toString("UTF-8");
+    }
+
+    /**
+     * Returns the Audit event type based on fedora event type and properties.
+     *
+     * @param eventTypes from Fedora
+     * @return Audit event
+     */
+    private static Optional<String> getAuditEventType(final List<String> eventTypes, final List<String> resourceType) {
+        // mapping event type/properties to audit event type
+        if (eventTypes.contains(EVENT_NAMESPACE + "ResourceCreation") || eventTypes.contains(AS_NAMESPACE + "Create")) {
+            if (resourceType.contains(REPOSITORY + "Binary")) {
+                return of(CONTENT_ADD);
+            } else {
+                return of(OBJECT_ADD);
+            }
+        } else if (eventTypes.contains(EVENT_NAMESPACE + "ResourceDeletion") ||
+                eventTypes.contains(AS_NAMESPACE + "Delete")) {
+            if (resourceType.contains(REPOSITORY + "Binary")) {
+                return of(CONTENT_REM);
+            } else {
+                return of(OBJECT_REM);
+            }
+        } else if (eventTypes.contains(EVENT_NAMESPACE + "ResourceModification") ||
+                eventTypes.contains(AS_NAMESPACE + "Update")) {
+            if (resourceType.contains(REPOSITORY + "Binary")) {
+                return of(CONTENT_MOD);
+            } else {
+                return of(METADATA_MOD);
+            }
+        }
+        return empty();
+    }
+
+
+}

--- a/umd-fcrepo-premis/src/main/java/edu/umd/lib/fcrepo/camel/premis/PremisComponent.java
+++ b/umd-fcrepo-premis/src/main/java/edu/umd/lib/fcrepo/camel/premis/PremisComponent.java
@@ -1,0 +1,88 @@
+package edu.umd.lib.fcrepo.camel.premis;
+
+import edu.umd.lib.osgi.service.AbstractManagedServiceInstance;
+import org.apache.camel.LoggingLevel;
+import org.apache.camel.builder.RouteBuilder;
+import org.slf4j.Logger;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * A component that runs a AuditPremisProcessor against the input stream to create a PREMIS-formatted
+ * audit event message suitable for recording in a triplestore.
+ */
+public class PremisComponent extends AbstractManagedServiceInstance {
+  private String inputStream;
+  private String outputStream;
+  private String eventBaseURI;
+
+  private static final String EVENT_BASE_URI = "CamelAuditEventBaseUri";
+  private static final Logger logger = getLogger(PremisComponent.class);
+
+  public PremisComponent() {
+  }
+
+  /**
+   * Returns a RouteBuilder, using the values from the instance variables
+   *
+   * @return a RouteBuilder incorporating an AuditPremisProcessor
+   */
+  @Override
+  protected RouteBuilder buildRoute() {
+    return new RouteBuilder() {
+      @Override
+      public void configure() {
+        from(inputStream)
+            .routeId("AuditPremisRouter " + inputStream)
+            .log(LoggingLevel.DEBUG, logger, "PremisComponent: ${header.CamelFcrepoAgent}")
+            .setHeader(EVENT_BASE_URI, simple(eventBaseURI))
+            .process(new AuditPremisProcessor())
+            .log(LoggingLevel.INFO, "org.fcrepo.camel.audit",
+                "Audit Event: ${headers.CamelFcrepoUri} :: ${headers[CamelAuditEventUri]}")
+            .to(outputStream);
+      }
+    };
+  }
+
+  /**
+   * Sets the input stream for the route.
+   *
+   * @param inputStream
+   *          the input stream for the route
+   */
+  public void setInputStream(String inputStream) {
+    this.inputStream = inputStream;
+  }
+
+  /**
+   * Sets the output stream for the route.
+   *
+   * @param outputStream
+   *          the output stream for the route
+   */
+  public void setOutputStream(String outputStream) {
+    this.outputStream = outputStream;
+  }
+
+  /**
+   * Sets the base URI to use for events
+   *
+   * @param eventBaseURI base URI for events
+   */
+  public void setEventBaseURI(String eventBaseURI) {
+    this.eventBaseURI = eventBaseURI;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append(this.getClass().getName() + " [inputStream=");
+    builder.append(inputStream);
+    builder.append(", outputStream=");
+    builder.append(outputStream);
+    builder.append(", routeId=");
+    builder.append(routeId);
+    builder.append("]");
+    return builder.toString();
+  }
+}

--- a/umd-fcrepo-premis/src/main/java/edu/umd/lib/fcrepo/camel/premis/PremisFactory.java
+++ b/umd-fcrepo-premis/src/main/java/edu/umd/lib/fcrepo/camel/premis/PremisFactory.java
@@ -1,0 +1,51 @@
+package edu.umd.lib.fcrepo.camel.premis;
+
+import edu.umd.lib.osgi.service.AbstractManagedServiceFactory;
+import org.apache.camel.CamelContext;
+import org.osgi.service.cm.ConfigurationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Dictionary;
+
+/**
+ * AbstractManagedServiceFactory implementation for creating PremisComponent instances.
+ */
+public class PremisFactory extends AbstractManagedServiceFactory<PremisComponent> {
+  private Logger log = LoggerFactory.getLogger(PremisFactory.class);
+
+  private final static String INPUT_STREAM = "input.stream";
+  private final static String OUTPUT_STREAM = "output.stream";
+  private final static String EVENT_BASE_URI = "event.baseURI";
+
+  /**
+   * Creates and returns a new PremisComponent from the given parameters.
+   *
+   * @param camelContext
+   *          the CamelContext for the component
+   * @param dict
+   *          the Dictionary containing the blueprint properties.
+   * @return a new PremisComponent from the given parameters.
+   */
+  @Override
+  protected PremisComponent createServiceInstance(CamelContext camelContext, Dictionary<String, ?> dict)
+      throws ConfigurationException {
+
+    String inputStream = getDictionaryEntry(dict, INPUT_STREAM);
+    String outputStream = getDictionaryEntry(dict, OUTPUT_STREAM);
+    String eventBaseURI = getDictionaryEntry(dict, EVENT_BASE_URI);
+
+    log.debug("inputStream: " + inputStream);
+    log.debug("outputStream: " + outputStream);
+    log.debug("eventBaseURI: " + eventBaseURI);
+
+    // Configuration was verified above, now create engine.
+    PremisComponent engine = new PremisComponent();
+    engine.setCamelContext(camelContext);
+    engine.setInputStream(inputStream);
+    engine.setOutputStream(outputStream);
+    engine.setEventBaseURI(eventBaseURI);
+
+    return engine;
+  }
+}

--- a/umd-fcrepo-premis/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/umd-fcrepo-premis/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+           xmlns:camel="http://camel.apache.org/schema/blueprint"
+           xsi:schemaLocation="
+               http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+               http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
+
+  <cm:property-placeholder persistent-id="edu.umd.lib.fcrepo.camel.premis" update-strategy="reload">
+    <cm:default-properties>
+      <cm:property name="edu.umd.lib.fcrepo.camel.premis.pid" value="edu.umd.lib.fcrepo.camel.premis"/>
+    </cm:default-properties>
+  </cm:property-placeholder>
+
+  <camelContext id="UmdFcrepoPremis" xmlns="http://camel.apache.org/schema/blueprint" autoStartup="true">
+  </camelContext>
+
+  <bean id="premisFactory" class="edu.umd.lib.fcrepo.camel.premis.PremisFactory"
+        init-method="init" destroy-method="destroy">
+    <property name="bundleContext" ref="blueprintBundleContext"/>
+    <property name="configurationPid" value="${edu.umd.lib.fcrepo.camel.premis.pid}"/>
+    <property name="camelContext" ref="UmdFcrepoPremis"/>
+  </bean>
+</blueprint>

--- a/umd-features/src/main/resources/features.xml
+++ b/umd-features/src/main/resources/features.xml
@@ -70,4 +70,11 @@
     <details>Installs the UMD Notification</details>
     <bundle>mvn:edu.umd.lib.fcrepo/umd-fcrepo-notification/${project.version}</bundle>
   </feature>
+
+  <feature name="umd-fcrepo-premis" version="${project.version}">
+    <details>Installs the UMD PREMIS event service.</details>
+
+    <bundle>mvn:edu.umd.lib.fcrepo/umd-fcrepo-premis/${project.version}</bundle>
+    <bundle>mvn:edu.umd.lib.fcrepo/umd-osgi-extensions/${project.version}</bundle>
+  </feature>
 </features>


### PR DESCRIPTION
* Converts the Fedora-generated JMS message to N-Triples formatted RDF using the PREMIS vocabulary
* Uses the same mappings as the fcrepo-audit-triplestore method
* Updated the umd-fcrepo-event-router to add JMS-friendly header types for user, user agent, event type, and resource type

https://issues.umd.edu/browse/LIBFCREPO-682